### PR TITLE
test: add API router coverage

### DIFF
--- a/src/test/apiTests/auth-api.test.ts
+++ b/src/test/apiTests/auth-api.test.ts
@@ -1,0 +1,169 @@
+import express from 'express';
+import request from 'supertest';
+
+const completeMock = jest.fn().mockResolvedValue(undefined);
+const unitMock = { complete: completeMock };
+
+jest.mock('../../backend/utils/unit', () => ({
+  Unit: {
+    create: jest.fn().mockResolvedValue(unitMock),
+  },
+}));
+
+const sessionServiceMock = {
+  getSession: jest.fn(),
+  invalidateSession: jest.fn(),
+};
+
+jest.mock('../../backend/services/session-service', () => ({
+  SessionService: jest.fn(() => sessionServiceMock),
+}));
+
+const playerServiceMock = {
+  getInfoByID: jest.fn(),
+};
+
+jest.mock('../../backend/services/player-service', () => ({
+  PlayerService: jest.fn(() => playerServiceMock),
+}));
+
+jest.mock('../../backend/middleware/rate-limiter', () => ({
+  registerRateLimiter: { middleware: () => (_req: any, _res: any, next: any) => next() },
+  loginRateLimiter: { middleware: () => (_req: any, _res: any, next: any) => next() },
+  authRateLimiter: { middleware: () => (_req: any, _res: any, next: any) => next() },
+  resendVerificationRateLimiter: { middleware: () => (_req: any, _res: any, next: any) => next() },
+  twoFactorRateLimiter: { middleware: () => (_req: any, _res: any, next: any) => next() },
+  challengeRateLimiter: { middleware: () => (_req: any, _res: any, next: any) => next() },
+}));
+
+jest.mock('../../backend/middleware/turnstile', () => ({
+  turnstileMiddleware: (_req: any, res: any, next: any) => {
+    res.locals.turnstileFailed = false;
+    next();
+  },
+}));
+
+jest.mock('../../backend/middleware/timing-guard', () => ({
+  timingGuard: (_req: any, _res: any, next: any) => next(),
+}));
+
+jest.mock('../../backend/middleware/header-guard', () => ({
+  headerGuard: (_req: any, _res: any, next: any) => next(),
+}));
+
+jest.mock('../../backend/middleware/behavior-guard', () => ({
+  behaviorGuard: (_req: any, _res: any, next: any) => next(),
+}));
+
+jest.mock('../../backend/middleware/datacenter-guard', () => ({
+  datacenterGuard: (_req: any, _res: any, next: any) => next(),
+}));
+
+jest.mock('../../backend/services/security-event-service', () => ({
+  logSecurityEvent: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../../backend/services/email-service', () => ({
+  sendVerificationEmail: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../../backend/utils/password', () => ({
+  hashPassword: jest.fn().mockResolvedValue('hashed'),
+  comparePassword: jest.fn().mockResolvedValue(true),
+  isHashed: jest.fn().mockReturnValue(true),
+}));
+
+jest.mock('../../backend/utils/bot-trap', () => ({
+  handleBotDetection: jest.fn().mockResolvedValue(false),
+  fakeAuthResponse: jest.fn(),
+  checkHoneypot: jest.fn().mockReturnValue(false),
+  logBot: jest.fn(),
+  tarPit: jest.fn().mockResolvedValue(undefined),
+  setBotHeaders: jest.fn(),
+  getClientIp: jest.fn().mockReturnValue('127.0.0.1'),
+}));
+
+jest.mock('../../backend/middleware/require-auth', () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    const sessionId = req.headers['session-id'];
+    if (!sessionId) {
+      res.status(401).json({ error: 'Missing session-id header' });
+      return;
+    }
+    req.playerId = 1;
+    next();
+  },
+}));
+
+import { authRouter } from '../../backend/routers/auth-router';
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api', authRouter);
+  return app;
+}
+
+const player = {
+  playerId: 1,
+  username: 'alice',
+  email: 'alice@example.com',
+  coins: 100,
+  violationCount: 0,
+  lastViolationAt: null,
+};
+
+describe('Auth API', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('GET /api/auth/me', () => {
+    it('returns 400 when session-id header is missing', async () => {
+      await request(createApp())
+        .get('/api/auth/me')
+        .expect(400)
+        .expect(res => {
+          expect(res.body.error).toBe('Missing session-id header');
+        });
+    });
+
+    it('returns 401 when session is invalid', async () => {
+      sessionServiceMock.getSession.mockResolvedValue(null);
+
+      await request(createApp())
+        .get('/api/auth/me')
+        .set('session-id', 'bad')
+        .expect(401);
+    });
+
+    it('returns current player without violation fields', async () => {
+      sessionServiceMock.getSession.mockResolvedValue({ sessionId: 's1', playerId: 1, expiresAt: new Date(Date.now() + 1000) });
+      playerServiceMock.getInfoByID.mockResolvedValue(player);
+
+      await request(createApp())
+        .get('/api/auth/me')
+        .set('session-id', 's1')
+        .expect(200)
+        .expect(res => {
+          expect(res.body).toEqual(expect.objectContaining({ playerId: 1, username: 'alice' }));
+          expect(res.body.violationCount).toBeUndefined();
+        });
+    });
+  });
+
+  describe('POST /api/auth/logout', () => {
+    it('invalidates a valid session', async () => {
+      sessionServiceMock.getSession.mockResolvedValue({ sessionId: 's1', playerId: 1 });
+      sessionServiceMock.invalidateSession.mockResolvedValue(true);
+
+      await request(createApp())
+        .post('/api/auth/logout')
+        .set('session-id', 's1')
+        .expect(200)
+        .expect(res => {
+          expect(res.body.message).toBe('Logout successful');
+        });
+    });
+  });
+});

--- a/src/test/apiTests/listing-api.test.ts
+++ b/src/test/apiTests/listing-api.test.ts
@@ -1,0 +1,152 @@
+import express from 'express';
+import request from 'supertest';
+
+function stmt(getResult: unknown = null) {
+  return {
+    get: jest.fn().mockResolvedValue(getResult),
+    all: jest.fn().mockResolvedValue([]),
+    run: jest.fn().mockResolvedValue({ changes: 1 }),
+  };
+}
+
+const unitMock = {
+  complete: jest.fn().mockResolvedValue(undefined),
+  prepare: jest.fn(),
+};
+
+jest.mock('../../backend/utils/unit', () => ({
+  Unit: {
+    create: jest.fn().mockResolvedValue(unitMock),
+  },
+}));
+
+const listingServiceMock = {
+  getActiveListings: jest.fn(),
+  getFilteredListings: jest.fn(),
+  getListingById: jest.fn(),
+  getListingsBySellerId: jest.fn(),
+  isStoveListed: jest.fn(),
+  isLootboxListed: jest.fn(),
+  createListing: jest.fn(),
+  updatePrice: jest.fn(),
+};
+
+jest.mock('../../backend/services/listing-service', () => ({
+  ListingService: jest.fn(() => listingServiceMock),
+}));
+
+jest.mock('../../backend/services/player-prestige-service', () => ({
+  PlayerPrestigeService: jest.fn(() => ({ addXP: jest.fn().mockResolvedValue(undefined) })),
+}));
+
+jest.mock('../../backend/services/punishment-service', () => ({
+  PunishmentService: jest.fn(() => ({ recordViolation: jest.fn().mockResolvedValue(undefined) })),
+}));
+
+jest.mock('../../backend/middleware/require-auth', () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!req.headers['session-id']) {
+      res.status(401).json({ error: 'Missing session-id header' });
+      return;
+    }
+    req.playerId = 1;
+    next();
+  },
+}));
+
+jest.mock('../../backend/middleware/ban-check', () => ({
+  checkPlayerBanned: jest.fn().mockResolvedValue(false),
+}));
+
+import { listingRouter } from '../../backend/routers/listing-router';
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api', listingRouter);
+  return app;
+}
+
+const listing = { listingId: 1, sellerId: 1, stoveId: 5, lootboxId: null, price: 200, status: 'active' };
+
+describe('Listing API', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    unitMock.prepare.mockReturnValue(stmt());
+  });
+
+  it('returns active listings', async () => {
+    listingServiceMock.getActiveListings.mockResolvedValue([listing]);
+
+    await request(createApp())
+      .get('/api/listings/active')
+      .expect(200)
+      .expect(res => {
+        expect(res.body).toEqual([listing]);
+      });
+  });
+
+  it('uses filtered listings when query filters are present', async () => {
+    listingServiceMock.getFilteredListings.mockResolvedValue([listing]);
+
+    await request(createApp())
+      .get('/api/listings/active?rarity=rare&minPrice=100&itemType=stove')
+      .expect(200);
+
+    expect(listingServiceMock.getFilteredListings).toHaveBeenCalledWith(
+      expect.objectContaining({ rarity: ['rare'], minPrice: 100, itemType: 'stove' }),
+      100,
+      0
+    );
+  });
+
+  it('validates listing id and returns 404 when missing', async () => {
+    await request(createApp()).get('/api/listings/bad').expect(400);
+
+    listingServiceMock.getListingById.mockResolvedValue(null);
+    await request(createApp()).get('/api/listings/99').expect(404);
+  });
+
+  it('allows sellers to view only their own listings', async () => {
+    listingServiceMock.getListingsBySellerId.mockResolvedValue([listing]);
+
+    await request(createApp())
+      .get('/api/players/1/listings')
+      .set('session-id', 's1')
+      .expect(200);
+
+    await request(createApp())
+      .get('/api/players/2/listings')
+      .set('session-id', 's1')
+      .expect(403);
+  });
+
+  it('creates a stove listing owned by the seller', async () => {
+    unitMock.prepare
+      .mockReturnValueOnce(stmt({ currentOwnerId: 1 }))
+      .mockReturnValueOnce(stmt({ playerId: 1 }))
+      .mockReturnValueOnce(stmt({ bannedAt: null }));
+    listingServiceMock.isStoveListed.mockResolvedValue(false);
+    listingServiceMock.createListing.mockResolvedValue([true, 7]);
+
+    await request(createApp())
+      .post('/api/listings')
+      .set('session-id', 's1')
+      .send({ sellerId: 1, stoveId: 5, price: 200 })
+      .expect(201)
+      .expect(res => {
+        expect(res.body.listingId).toBe(7);
+      });
+  });
+
+  it('updates listing price only for the seller', async () => {
+    listingServiceMock.getListingById.mockResolvedValue(listing);
+    listingServiceMock.updatePrice.mockResolvedValue(true);
+
+    await request(createApp())
+      .patch('/api/listings/1/price')
+      .set('session-id', 's1')
+      .send({ price: 300 })
+      .expect(200);
+  });
+});

--- a/src/test/apiTests/lootbox-api.test.ts
+++ b/src/test/apiTests/lootbox-api.test.ts
@@ -1,0 +1,130 @@
+import express from 'express';
+import request from 'supertest';
+
+const unitMock = { complete: jest.fn().mockResolvedValue(undefined) };
+
+jest.mock('../../backend/utils/unit', () => ({
+  Unit: {
+    create: jest.fn().mockResolvedValue(unitMock),
+  },
+}));
+
+const lootboxServiceMock = {
+  getRecentPulls: jest.fn(),
+  getLootboxById: jest.fn(),
+  getLootboxesByPlayerId: jest.fn(),
+  openLootbox: jest.fn(),
+};
+
+jest.mock('../../backend/services/lootbox-service', () => ({
+  LootboxService: jest.fn(() => lootboxServiceMock),
+}));
+
+const listingServiceMock = {
+  isLootboxListed: jest.fn(),
+};
+
+jest.mock('../../backend/services/listing-service', () => ({
+  ListingService: jest.fn(() => listingServiceMock),
+}));
+
+jest.mock('../../backend/middleware/require-auth', () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!req.headers['session-id']) {
+      res.status(401).json({ error: 'Missing session-id header' });
+      return;
+    }
+    req.playerId = 1;
+    next();
+  },
+}));
+
+jest.mock('../../backend/middleware/admin', () => ({
+  requireAdmin: (_req: any, _res: any, next: any) => next(),
+}));
+
+jest.mock('../../backend/middleware/ban-check', () => ({
+  checkPlayerBanned: jest.fn().mockResolvedValue(false),
+}));
+
+import { lootboxRouter } from '../../backend/routers/lootbox-router';
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api', lootboxRouter);
+  return app;
+}
+
+const lootbox = { lootboxId: 10, playerId: 1, lootboxTypeId: 1, openedAt: null, acquiredHow: 'reward' };
+
+describe('Lootbox API', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns recent pulls with relative time labels', async () => {
+    lootboxServiceMock.getRecentPulls.mockResolvedValue([
+      { username: 'alice', name: 'Basic Stove', rarity: 'common', imageUrl: '/stove.png', openedAt: new Date().toISOString() },
+    ]);
+
+    await request(createApp())
+      .get('/api/lootboxes/recent')
+      .expect(200)
+      .expect(res => {
+        expect(res.body[0]).toEqual(expect.objectContaining({ username: 'alice', itemName: 'Basic Stove', timeAgo: 'now' }));
+      });
+  });
+
+  it('validates lootbox id format', async () => {
+    await request(createApp())
+      .get('/api/lootboxes/nope')
+      .expect(400);
+  });
+
+  it('returns 404 when lootbox is not found', async () => {
+    lootboxServiceMock.getLootboxById.mockResolvedValue(null);
+
+    await request(createApp())
+      .get('/api/lootboxes/99')
+      .expect(404);
+  });
+
+  it('allows a player to view only their own lootboxes', async () => {
+    lootboxServiceMock.getLootboxesByPlayerId.mockResolvedValue([lootbox]);
+
+    await request(createApp())
+      .get('/api/players/1/lootboxes')
+      .set('session-id', 's1')
+      .expect(200)
+      .expect(res => {
+        expect(res.body).toEqual([lootbox]);
+      });
+
+    await request(createApp())
+      .get('/api/players/2/lootboxes')
+      .set('session-id', 's1')
+      .expect(403);
+  });
+
+  it('opens an owned lootbox', async () => {
+    lootboxServiceMock.getLootboxById.mockResolvedValue(lootbox);
+    listingServiceMock.isLootboxListed.mockResolvedValue(false);
+    lootboxServiceMock.openLootbox.mockResolvedValue([true, {
+      stoveId: 5,
+      stoveName: 'Basic Stove',
+      rarity: 'common',
+      imageUrl: '/stove.png',
+      lootboxId: 10,
+    }]);
+
+    await request(createApp())
+      .post('/api/lootboxes/10/open')
+      .set('session-id', 's1')
+      .expect(201)
+      .expect(res => {
+        expect(res.body.message).toBe('Lootbox opened successfully');
+        expect(res.body.stoveId).toBe(5);
+      });
+  });
+});

--- a/src/test/apiTests/ownership-api.test.ts
+++ b/src/test/apiTests/ownership-api.test.ts
@@ -1,0 +1,114 @@
+import express from 'express';
+import request from 'supertest';
+
+const unitMock = { complete: jest.fn().mockResolvedValue(undefined) };
+
+jest.mock('../../backend/utils/unit', () => ({
+  Unit: {
+    create: jest.fn().mockResolvedValue(unitMock),
+  },
+}));
+
+const ownershipServiceMock = {
+  getOwnershipById: jest.fn(),
+  getOwnershipsByPlayerId: jest.fn(),
+  getCurrentOwnership: jest.fn(),
+  countOwnershipChanges: jest.fn(),
+};
+
+jest.mock('../../backend/services/ownership-service', () => ({
+  OwnershipService: jest.fn(() => ownershipServiceMock),
+}));
+
+jest.mock('../../backend/middleware/require-auth', () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!req.headers['session-id']) {
+      res.status(401).json({ error: 'Missing session-id header' });
+      return;
+    }
+    req.playerId = 1;
+    next();
+  },
+}));
+
+jest.mock('../../backend/middleware/admin', () => ({
+  requireAdmin: (_req: any, _res: any, next: any) => next(),
+}));
+
+import { ownershipRouter } from '../../backend/routers/ownership-router';
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api', ownershipRouter);
+  return app;
+}
+
+const ownership = { ownershipId: 1, stoveId: 5, playerId: 1, acquiredHow: 'lootbox' };
+
+describe('Ownership API', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('validates ownership id format', async () => {
+    await request(createApp())
+      .get('/api/ownerships/bad')
+      .expect(400);
+  });
+
+  it('returns 404 when ownership is not found', async () => {
+    ownershipServiceMock.getOwnershipById.mockResolvedValue(null);
+
+    await request(createApp())
+      .get('/api/ownerships/999')
+      .expect(404);
+  });
+
+  it('returns ownership by id', async () => {
+    ownershipServiceMock.getOwnershipById.mockResolvedValue(ownership);
+
+    await request(createApp())
+      .get('/api/ownerships/1')
+      .expect(200)
+      .expect(res => {
+        expect(res.body).toEqual(ownership);
+      });
+  });
+
+  it('allows players to view only their own ownerships', async () => {
+    ownershipServiceMock.getOwnershipsByPlayerId.mockResolvedValue([ownership]);
+
+    await request(createApp())
+      .get('/api/players/1/ownerships')
+      .set('session-id', 's1')
+      .expect(200);
+
+    await request(createApp())
+      .get('/api/players/2/ownerships')
+      .set('session-id', 's1')
+      .expect(403);
+  });
+
+  it('returns current owner for a stove', async () => {
+    ownershipServiceMock.getCurrentOwnership.mockResolvedValue(ownership);
+
+    await request(createApp())
+      .get('/api/stoves/5/current-owner')
+      .expect(200)
+      .expect(res => {
+        expect(res.body).toEqual(ownership);
+      });
+  });
+
+  it('returns ownership change count', async () => {
+    ownershipServiceMock.countOwnershipChanges.mockResolvedValue(3);
+
+    await request(createApp())
+      .get('/api/stoves/5/ownership-changes/count')
+      .expect(200)
+      .expect(res => {
+        expect(res.body).toEqual({ count: 3 });
+      });
+  });
+});

--- a/src/test/apiTests/player-api.test.ts
+++ b/src/test/apiTests/player-api.test.ts
@@ -1,0 +1,110 @@
+import express from 'express';
+import request from 'supertest';
+
+const unitMock = { complete: jest.fn().mockResolvedValue(undefined) };
+
+jest.mock('../../backend/utils/unit', () => ({
+  Unit: {
+    create: jest.fn().mockResolvedValue(unitMock),
+  },
+}));
+
+const playerServiceMock = {
+  getAllPublicPlayers: jest.fn(),
+  getPublicPlayerById: jest.fn(),
+  getPlayerByUsername: jest.fn(),
+};
+
+jest.mock('../../backend/services/player-service', () => ({
+  PlayerService: jest.fn(() => playerServiceMock),
+}));
+
+jest.mock('../../backend/middleware/require-auth', () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!req.headers['session-id']) {
+      res.status(401).json({ error: 'Missing session-id header' });
+      return;
+    }
+    req.playerId = 1;
+    next();
+  },
+}));
+
+jest.mock('../../backend/middleware/admin', () => ({
+  requireAdmin: (_req: any, _res: any, next: any) => next(),
+}));
+
+jest.mock('../../backend/services/email-service', () => ({
+  sendVerificationEmail: jest.fn().mockResolvedValue(undefined),
+}));
+
+import { playerRouter } from '../../backend/routers/player-router';
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api', playerRouter);
+  return app;
+}
+
+const player = { playerId: 1, username: 'alice', email: 'alice@example.com' };
+
+describe('Player API', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns all public players', async () => {
+    playerServiceMock.getAllPublicPlayers.mockResolvedValue([player]);
+
+    await request(createApp())
+      .get('/api/players')
+      .expect(200)
+      .expect(res => {
+        expect(res.body).toEqual([player]);
+      });
+  });
+
+  it('returns 400 for invalid player id', async () => {
+    await request(createApp())
+      .get('/api/players/not-a-number')
+      .expect(400);
+  });
+
+  it('returns 404 when player is not found', async () => {
+    playerServiceMock.getPublicPlayerById.mockResolvedValue(null);
+
+    await request(createApp())
+      .get('/api/players/999')
+      .expect(404);
+  });
+
+  it('returns a player by id', async () => {
+    playerServiceMock.getPublicPlayerById.mockResolvedValue(player);
+
+    await request(createApp())
+      .get('/api/players/1')
+      .expect(200)
+      .expect(res => {
+        expect(res.body).toEqual(player);
+      });
+  });
+
+  it('looks up player by username', async () => {
+    playerServiceMock.getPlayerByUsername.mockResolvedValue(player);
+
+    await request(createApp())
+      .get('/api/players/lookup/alice')
+      .expect(200)
+      .expect(res => {
+        expect(res.body).toEqual({ playerId: 1, username: 'alice' });
+      });
+  });
+
+  it('keeps direct player creation disabled', async () => {
+    await request(createApp())
+      .post('/api/players')
+      .send({ username: 'new' })
+      .expect(410);
+  });
+});

--- a/src/test/apiTests/shop-api.test.ts
+++ b/src/test/apiTests/shop-api.test.ts
@@ -1,0 +1,137 @@
+import express from 'express';
+import request from 'supertest';
+
+const unitMock = { complete: jest.fn().mockResolvedValue(undefined) };
+
+jest.mock('../../backend/utils/unit', () => ({
+  Unit: {
+    create: jest.fn().mockResolvedValue(unitMock),
+  },
+}));
+
+const shopServiceMock = {
+  getShopItems: jest.fn(),
+  purchaseItem: jest.fn(),
+  getDailyRewardStatus: jest.fn(),
+  sellStove: jest.fn(),
+  claimDailyReward: jest.fn(),
+};
+
+jest.mock('../../backend/services/shop-service', () => ({
+  ShopService: jest.fn(() => shopServiceMock),
+}));
+
+const rotationServiceMock = {
+  rotate: jest.fn(),
+};
+
+jest.mock('../../backend/services/shop-rotation-service', () => ({
+  ShopRotationService: jest.fn(() => rotationServiceMock),
+}));
+
+jest.mock('../../backend/services/quest-service', () => ({
+  QuestService: jest.fn(() => ({ trackProgress: jest.fn().mockResolvedValue(undefined) })),
+}));
+
+jest.mock('../../backend/middleware/require-auth', () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!req.headers['session-id']) {
+      res.status(401).json({ error: 'Missing session-id header' });
+      return;
+    }
+    req.playerId = 1;
+    next();
+  },
+}));
+
+jest.mock('../../backend/middleware/admin', () => ({
+  requireAdmin: (_req: any, _res: any, next: any) => next(),
+}));
+
+jest.mock('../../backend/middleware/ban-check', () => ({
+  checkPlayerBanned: jest.fn().mockResolvedValue(false),
+}));
+
+import { shopRouter } from '../../backend/routers/shop-router';
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api', shopRouter);
+  return app;
+}
+
+describe('Shop API', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns shop items', async () => {
+    shopServiceMock.getShopItems.mockResolvedValue([{ listingId: 1, price: 100 }]);
+
+    await request(createApp())
+      .get('/api/shop/items')
+      .expect(200)
+      .expect(res => {
+        expect(res.body).toEqual([{ listingId: 1, price: 100 }]);
+      });
+  });
+
+  it('validates buy request body', async () => {
+    await request(createApp())
+      .post('/api/shop/buy')
+      .set('session-id', 's1')
+      .send({})
+      .expect(400);
+  });
+
+  it('buys a shop item', async () => {
+    shopServiceMock.purchaseItem.mockResolvedValue({ success: true, itemId: 99 });
+
+    await request(createApp())
+      .post('/api/shop/buy')
+      .set('session-id', 's1')
+      .send({ listingId: 1 })
+      .expect(200)
+      .expect(res => {
+        expect(res.body).toEqual({ message: 'Purchase successful', itemId: 99 });
+      });
+  });
+
+  it('returns daily reward status', async () => {
+    shopServiceMock.getDailyRewardStatus.mockResolvedValue({ canClaim: true, streakCount: 2 });
+
+    await request(createApp())
+      .get('/api/shop/daily-status')
+      .set('session-id', 's1')
+      .expect(200)
+      .expect(res => {
+        expect(res.body.canClaim).toBe(true);
+      });
+  });
+
+  it('claims daily reward', async () => {
+    shopServiceMock.claimDailyReward.mockResolvedValue({ success: true, reward: 100, newStreak: 3 });
+
+    await request(createApp())
+      .post('/api/shop/claim-daily')
+      .set('session-id', 's1')
+      .expect(200)
+      .expect(res => {
+        expect(res.body.reward).toBe(100);
+        expect(res.body.newStreak).toBe(3);
+      });
+  });
+
+  it('rotates shop as admin', async () => {
+    rotationServiceMock.rotate.mockResolvedValue({ newFeatured: [1, 2] });
+
+    await request(createApp())
+      .post('/api/shop/rotate')
+      .set('session-id', 'admin')
+      .expect(200)
+      .expect(res => {
+        expect(res.body).toEqual({ newFeatured: [1, 2] });
+      });
+  });
+});

--- a/src/test/apiTests/trade-api.test.ts
+++ b/src/test/apiTests/trade-api.test.ts
@@ -1,0 +1,183 @@
+import express from 'express';
+import request from 'supertest';
+
+const unitMock = {
+  complete: jest.fn().mockResolvedValue(undefined),
+  savepoint: jest.fn().mockRejectedValue(new Error('skip achievements')),
+  rollbackToSavepoint: jest.fn().mockResolvedValue(undefined),
+};
+
+jest.mock('../../backend/utils/unit', () => ({
+  Unit: {
+    create: jest.fn().mockResolvedValue(unitMock),
+  },
+}));
+
+const tradeServiceMock = {
+  getRecentTrades: jest.fn(),
+  countTrades: jest.fn(),
+  getTradeById: jest.fn(),
+  getTradesByBuyerId: jest.fn(),
+  createTrade: jest.fn(),
+};
+
+jest.mock('../../backend/services/trade-service', () => ({
+  TradeService: jest.fn(() => tradeServiceMock),
+}));
+
+const listingServiceMock = {
+  getListingById: jest.fn(),
+  markAsSold: jest.fn(),
+};
+
+jest.mock('../../backend/services/listing-service', () => ({
+  ListingService: jest.fn(() => listingServiceMock),
+}));
+
+const playerServiceMock = {
+  getInfoByID: jest.fn(),
+  deductCoinsAtomic: jest.fn(),
+  addCoinsAtomic: jest.fn(),
+};
+
+jest.mock('../../backend/services/player-service', () => ({
+  PlayerService: jest.fn(() => playerServiceMock),
+}));
+
+jest.mock('../../backend/services/stove-service', () => ({
+  StoveService: jest.fn(() => ({
+    updateOwner: jest.fn().mockResolvedValue(true),
+    getStoveById: jest.fn().mockResolvedValue({ stoveId: 5, typeId: 2 }),
+  })),
+}));
+
+jest.mock('../../backend/services/ownership-service', () => ({
+  OwnershipService: jest.fn(() => ({ createOwnership: jest.fn().mockResolvedValue([true, 1]) })),
+}));
+
+jest.mock('../../backend/services/price-history-service', () => ({
+  PriceHistoryService: jest.fn(() => ({ recordSale: jest.fn().mockResolvedValue([true, 1]) })),
+}));
+
+jest.mock('../../backend/services/coin-transaction-service', () => ({
+  CoinTransactionService: jest.fn(() => ({ create: jest.fn().mockResolvedValue([true, 1]) })),
+}));
+
+jest.mock('../../backend/services/player-prestige-service', () => ({
+  PlayerPrestigeService: jest.fn(() => ({ addXP: jest.fn().mockResolvedValue(undefined) })),
+}));
+
+jest.mock('../../backend/services/notification-service', () => ({
+  NotificationService: jest.fn(() => ({ create: jest.fn().mockResolvedValue([true, 1]) })),
+}));
+
+jest.mock('../../backend/services/quest-service', () => ({
+  QuestService: jest.fn(() => ({ trackProgress: jest.fn().mockResolvedValue(undefined) })),
+}));
+
+jest.mock('../../backend/services/punishment-service', () => ({
+  PunishmentService: jest.fn(() => ({ recordViolation: jest.fn().mockResolvedValue(undefined) })),
+}));
+
+jest.mock('../../backend/middleware/require-auth', () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!req.headers['session-id']) {
+      res.status(401).json({ error: 'Missing session-id header' });
+      return;
+    }
+    req.playerId = 1;
+    next();
+  },
+}));
+
+jest.mock('../../backend/middleware/admin', () => ({
+  requireAdmin: (_req: any, _res: any, next: any) => next(),
+}));
+
+import { tradeRouter } from '../../backend/routers/trade-router';
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api', tradeRouter);
+  return app;
+}
+
+const trade = { tradeId: 1, listingId: 10, buyerId: 1 };
+const listing = { listingId: 10, sellerId: 2, stoveId: 5, lootboxId: null, price: 100, status: 'active' };
+const buyer = { playerId: 1, coins: 500, bannedAt: null };
+const seller = { playerId: 2, coins: 50, bannedAt: null };
+
+describe('Trade API', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns recent trades and trade count', async () => {
+    tradeServiceMock.getRecentTrades.mockResolvedValue([trade]);
+    tradeServiceMock.countTrades.mockResolvedValue(3);
+
+    await request(createApp()).get('/api/trades/recent').expect(200);
+    await request(createApp())
+      .get('/api/trades/count')
+      .expect(200)
+      .expect(res => {
+        expect(res.body).toEqual({ count: 3 });
+      });
+  });
+
+  it('validates trade id and returns 404 when missing', async () => {
+    await request(createApp()).get('/api/trades/bad').expect(400);
+
+    tradeServiceMock.getTradeById.mockResolvedValue(null);
+    await request(createApp()).get('/api/trades/99').expect(404);
+  });
+
+  it('allows buyers to view only their own trades', async () => {
+    tradeServiceMock.getTradesByBuyerId.mockResolvedValue([trade]);
+
+    await request(createApp())
+      .get('/api/players/1/trades')
+      .set('session-id', 's1')
+      .expect(200);
+
+    await request(createApp())
+      .get('/api/players/2/trades')
+      .set('session-id', 's1')
+      .expect(403);
+  });
+
+  it('executes a stove trade', async () => {
+    listingServiceMock.getListingById.mockResolvedValue(listing);
+    playerServiceMock.getInfoByID
+      .mockResolvedValueOnce(buyer)
+      .mockResolvedValueOnce(seller)
+      .mockResolvedValueOnce(seller);
+    playerServiceMock.deductCoinsAtomic.mockResolvedValue(true);
+    playerServiceMock.addCoinsAtomic.mockResolvedValue(true);
+    listingServiceMock.markAsSold.mockResolvedValue(true);
+    tradeServiceMock.createTrade.mockResolvedValue([true, 99]);
+
+    await request(createApp())
+      .post('/api/trades')
+      .set('session-id', 's1')
+      .send({ listingId: 10, buyerId: 1 })
+      .expect(201)
+      .expect(res => {
+        expect(res.body).toEqual({ tradeId: 99, message: 'Trade executed successfully' });
+      });
+  });
+
+  it('rejects buying your own listing', async () => {
+    listingServiceMock.getListingById.mockResolvedValue({ ...listing, sellerId: 1 });
+
+    await request(createApp())
+      .post('/api/trades')
+      .set('session-id', 's1')
+      .send({ listingId: 10, buyerId: 1 })
+      .expect(400)
+      .expect(res => {
+        expect(res.body.error).toBe('Cannot buy your own listing');
+      });
+  });
+});

--- a/src/test/gameEngineTests/blackjack-edge-cases.test.ts
+++ b/src/test/gameEngineTests/blackjack-edge-cases.test.ts
@@ -1,0 +1,114 @@
+import { BlackJackEngine } from "../../backend/game-engines/blackjack-engine";
+import { BlackjackState } from "../../backend/game-logic/blackjack-types";
+import { RoomPlayerRow } from "../../shared/model";
+
+describe("BlackJack Engine edge cases", () => {
+  const engine = new BlackJackEngine();
+
+  const players: RoomPlayerRow[] = [
+    { roomPlayerId: "rp1", roomId: "r1", playerId: 1, username: "Alice", connectionState: "connected", seatIndex: 0 },
+    { roomPlayerId: "rp2", roomId: "r1", playerId: 2, username: "Bob", connectionState: "connected", seatIndex: 1 },
+  ];
+
+  function makeState(overrides: Partial<BlackjackState> = {}): BlackjackState {
+    return {
+      status: "active",
+      phase: "player_turn",
+      deck: ["2c", "3c", "4c", "5c", "6c"],
+      dealerHand: ["9h", "7d"],
+      players: [
+        {
+          playerId: 1,
+          username: "Alice",
+          activeTitle: null,
+          activeBanner: null,
+          hands: [["Ah", "Kd"]],
+          bets: [20],
+          stack: 980,
+          result: "blackjack",
+        },
+        {
+          playerId: 2,
+          username: "Bob",
+          activeTitle: null,
+          activeBanner: null,
+          hands: [["Th", "8d"]],
+          bets: [20],
+          stack: 980,
+          result: "playing",
+        },
+      ],
+      activePlayer: 2,
+      activeHandIndex: 0,
+      currentBet: 20,
+      log: [],
+      ...overrides,
+    };
+  }
+
+  test("natural blackjack pays 3:2 after another player finishes the hand", () => {
+    const result = engine.processAction(
+      makeState() as unknown as Record<string, unknown>,
+      { type: "stand" },
+      2
+    );
+
+    expect(result.valid).toBe(true);
+    const state = result.newFullState as unknown as BlackjackState;
+    const blackjackPlayer = state.players.find((p) => p.playerId === 1)!;
+
+    expect(state.phase).toBe("settled");
+    expect(blackjackPlayer.result).toBe("won");
+    expect(blackjackPlayer.stack).toBe(1030);
+    expect(state.winners).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          playerId: 1,
+          amount: 30,
+          handName: "Blackjack",
+        }),
+      ])
+    );
+  });
+
+  test("next hand action is rejected during active play", () => {
+    const state = makeState();
+    const result = engine.processAction(
+      state as unknown as Record<string, unknown>,
+      { type: "next_hand" },
+      2
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.errorMessage).toBe("Use resetForNextHand instead");
+    expect(result.newFullState).toBe(state);
+  });
+
+  test("reset keeps only players still present in the room", () => {
+    const state = makeState({
+      phase: "settled",
+      activePlayer: -1,
+      players: [
+        { ...makeState().players[0], stack: 1250, result: "won" },
+        { ...makeState().players[1], stack: 0, result: "lost" },
+      ],
+    });
+
+    const nextState = engine.resetForNextHand(
+      state as unknown as Record<string, unknown>,
+      [players[0]]
+    ) as unknown as BlackjackState;
+
+    expect(nextState.players).toHaveLength(1);
+    expect(nextState.players[0]).toEqual(
+      expect.objectContaining({
+        playerId: 1,
+        username: "Alice",
+        stack: 1250,
+        hands: [[]],
+        bets: [0],
+        result: "playing",
+      })
+    );
+  });
+});

--- a/src/test/gameEngineTests/poker-edge-cases.test.ts
+++ b/src/test/gameEngineTests/poker-edge-cases.test.ts
@@ -1,0 +1,120 @@
+import { PokerEngine } from "../../backend/game-engines/poker-engine";
+import { PokerState } from "../../backend/game-logic/poker-types";
+
+describe("PokerEngine edge cases", () => {
+  const engine = new PokerEngine();
+
+  function makeRiverState(overrides: Partial<PokerState> = {}): PokerState {
+    return {
+      status: "active",
+      phase: "river",
+      deck: ["2c", "3d", "4h"],
+      communityCards: ["Ah", "Kh", "Qh", "Jh", "2s"],
+      pots: [{ amount: 200, eligiblePlayers: [1, 2] }],
+      currentBet: 0,
+      dealerPosition: 0,
+      activePlayer: 1,
+      players: [
+        {
+          playerId: 1,
+          username: "Alice",
+          activeTitle: null,
+          activeBanner: null,
+          hand: ["Th", "3c"],
+          stack: 900,
+          bet: 0,
+          totalBet: 100,
+          folded: false,
+          allIn: false,
+        },
+        {
+          playerId: 2,
+          username: "Bob",
+          activeTitle: null,
+          activeBanner: null,
+          hand: ["As", "Ad"],
+          stack: 900,
+          bet: 0,
+          totalBet: 100,
+          folded: false,
+          allIn: false,
+        },
+      ],
+      playersToAct: [1],
+      log: [],
+      ...overrides,
+    };
+  }
+
+  test("river check resolves showdown and awards the pot to the best hand", () => {
+    const result = engine.processAction(
+      makeRiverState() as unknown as Record<string, unknown>,
+      { type: "check" },
+      1
+    );
+
+    expect(result.valid).toBe(true);
+    const state = result.newFullState as unknown as PokerState;
+
+    expect(state.phase).toBe("showdown");
+    expect(state.activePlayer).toBe(-1);
+    expect(state.players.find((p) => p.playerId === 1)?.stack).toBe(1100);
+    expect(state.players.find((p) => p.playerId === 2)?.stack).toBe(900);
+    expect(state.pots[0].amount).toBe(0);
+    expect(state.winners).toEqual([
+      { playerId: 1, amount: 200, handName: "Straight Flush" },
+    ]);
+  });
+
+  test("showdown player views reveal hands and include hand names", () => {
+    const state = engine.processAction(
+      makeRiverState() as unknown as Record<string, unknown>,
+      { type: "check" },
+      1
+    ).newFullState as unknown as PokerState;
+
+    const view = engine.getPlayerView(
+      state as unknown as Record<string, unknown>,
+      2
+    ) as unknown as { players: Array<{ playerId: number; hand: string[]; handName?: string }> };
+
+    expect(view.players.find((p) => p.playerId === 1)?.hand).toEqual(["Th", "3c"]);
+    expect(view.players.find((p) => p.playerId === 1)?.handName).toBe("Straight Flush");
+    expect(view.players.find((p) => p.playerId === 2)?.hand).toEqual(["As", "Ad"]);
+    expect(view.players.find((p) => p.playerId === 2)?.handName).toBe("Three of a Kind");
+  });
+
+  test("folded and all-in players cannot act even if state points at them", () => {
+    const foldedState = makeRiverState({
+      players: [
+        { ...makeRiverState().players[0], folded: true },
+        makeRiverState().players[1],
+      ],
+    });
+
+    const foldedResult = engine.processAction(
+      foldedState as unknown as Record<string, unknown>,
+      { type: "check" },
+      1
+    );
+
+    expect(foldedResult.valid).toBe(false);
+    expect(foldedResult.errorMessage).toBe("Player cannot act");
+
+    const allInState = makeRiverState({
+      players: [
+        { ...makeRiverState().players[0], allIn: true },
+        makeRiverState().players[1],
+      ],
+    });
+
+    const allInResult = engine.processAction(
+      allInState as unknown as Record<string, unknown>,
+      { type: "check" },
+      1
+    );
+
+    expect(allInResult.valid).toBe(false);
+    expect(allInResult.errorMessage).toBe("Player cannot act");
+  });
+});

--- a/src/test/gameEngineTests/roulette-edge-cases.test.ts
+++ b/src/test/gameEngineTests/roulette-edge-cases.test.ts
@@ -1,0 +1,102 @@
+import { RouletteEngine, RouletteState } from "../../backend/game-engines/roulette-engine";
+import { RoomPlayerRow } from "../../shared/model";
+
+describe("Roulette Engine edge cases", () => {
+  const engine = new RouletteEngine();
+
+  const players: RoomPlayerRow[] = [
+    { playerId: 1, username: "Alice", coins: 1000, activeTitle: null, activeBanner: null } as RoomPlayerRow,
+    { playerId: 2, username: "Bob", coins: 1000, activeTitle: null, activeBanner: null } as RoomPlayerRow,
+  ];
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function bet(
+    state: Record<string, unknown>,
+    betType: string,
+    amount = 10,
+    number?: number
+  ): Record<string, unknown> {
+    return engine.processAction(state, { type: "bet", betType, amount, number }, 1)
+      .newFullState;
+  }
+
+  test("controlled red odd low straight dozen and column bets pay correctly", () => {
+    jest.spyOn(Math, "random").mockReturnValue(7 / 37);
+    let state = engine.createInitialState(players);
+
+    state = bet(state, "red");
+    state = bet(state, "odd");
+    state = bet(state, "low");
+    state = bet(state, "straight", 10, 7);
+    state = bet(state, "dozen1");
+    state = bet(state, "column1");
+
+    const result = engine.processAction(state, { type: "spin" }, 1);
+
+    expect(result.valid).toBe(true);
+    const settled = result.newFullState as unknown as RouletteState;
+    const player = settled.players.find((p) => p.playerId === 1)!;
+
+    expect(settled.winningNumber).toBe(7);
+    expect(settled.winningColor).toBe("red");
+    expect(player.result).toBe("won");
+    expect(player.stack).toBe(1420);
+    expect(settled.winners).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ betType: "straight", amount: 350 }),
+        expect.objectContaining({ betType: "dozen1", amount: 20 }),
+        expect.objectContaining({ betType: "column1", amount: 20 }),
+      ])
+    );
+  });
+
+  test("zero only pays green straight bets and loses even-money outside bets", () => {
+    jest.spyOn(Math, "random").mockReturnValue(0);
+    let state = engine.createInitialState(players);
+
+    state = bet(state, "straight", 10, 0);
+    state = bet(state, "red");
+    state = bet(state, "black");
+    state = bet(state, "even");
+    state = bet(state, "odd");
+    state = bet(state, "high");
+    state = bet(state, "low");
+
+    const settled = engine.processAction(state, { type: "spin" }, 1)
+      .newFullState as unknown as RouletteState;
+    const player = settled.players.find((p) => p.playerId === 1)!;
+
+    expect(settled.winningNumber).toBe(0);
+    expect(settled.winningColor).toBe("green");
+    expect(player.result).toBe("won");
+    expect(player.stack).toBe(1290);
+    expect(settled.winners).toEqual([
+      { playerId: 1, amount: 350, betType: "straight" },
+    ]);
+  });
+
+  test("invalid bet type and out-of-range straight bets keep the original state", () => {
+    const state = engine.createInitialState(players);
+
+    const invalidType = engine.processAction(
+      state,
+      { type: "bet", amount: 10, betType: "split" },
+      1
+    );
+    const invalidNumber = engine.processAction(
+      state,
+      { type: "bet", amount: 10, betType: "straight", number: 37 },
+      1
+    );
+
+    expect(invalidType.valid).toBe(false);
+    expect(invalidType.errorMessage).toBe("Invalid bet type: split");
+    expect(invalidType.newFullState).toBe(state);
+    expect(invalidNumber.valid).toBe(false);
+    expect(invalidNumber.errorMessage).toBe("Straight bet requires a number 0-36");
+    expect(invalidNumber.newFullState).toBe(state);
+  });
+});

--- a/src/test/integrationTests/lootbox-opening-flow.integration.test.ts
+++ b/src/test/integrationTests/lootbox-opening-flow.integration.test.ts
@@ -1,0 +1,118 @@
+import { Unit } from "../../backend/utils/unit";
+
+jest.mock("../../backend/services/player-prestige-service", () => ({
+  PlayerPrestigeService: jest.fn(() => ({
+    addXP: jest.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+jest.mock("../../backend/services/achievement-engine", () => ({
+  AchievementEngine: jest.fn(() => ({
+    checkLootboxAchievements: jest.fn().mockResolvedValue(undefined),
+    checkWealthAchievements: jest.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+jest.mock("../../backend/services/pity-service", () => ({
+  PityService: jest.fn(() => ({
+    checkPity: jest.fn().mockResolvedValue(null),
+    resetCounter: jest.fn().mockResolvedValue(undefined),
+    incrementCounter: jest.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+jest.mock("../../backend/services/quest-service", () => ({
+  QuestService: jest.fn(() => ({
+    trackProgress: jest.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+import { LootboxService } from "../../backend/services/lootbox-service";
+
+function mockStmt(getResult: unknown = null, allResult: unknown[] = [], runResult = { changes: 1 }) {
+  return {
+    get: jest.fn().mockResolvedValue(getResult),
+    all: jest.fn().mockResolvedValue(allResult),
+    run: jest.fn().mockResolvedValue(runResult),
+  };
+}
+
+function mockUnitSequence(stmts: ReturnType<typeof mockStmt>[]) {
+  let callIndex = 0;
+  return {
+    prepare: jest.fn().mockImplementation(() => {
+      const stmt = stmts[Math.min(callIndex, stmts.length - 1)];
+      callIndex++;
+      return stmt;
+    }),
+    getLastRowId: jest.fn(),
+    savepoint: jest.fn().mockResolvedValue(undefined),
+    rollbackToSavepoint: jest.fn().mockResolvedValue(undefined),
+  } as unknown as Unit;
+}
+
+describe("Lootbox opening integration flow", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("opening an owned unlisted lootbox creates a stove, marks the box opened, creates a drop, and decrements count", async () => {
+    jest.spyOn(Math, "random").mockReturnValue(0);
+
+    const insertStoveStmt = mockStmt(null, [], { changes: 1 });
+    const openLootboxStmt = mockStmt(null, [], { changes: 1 });
+    const insertDropStmt = mockStmt(null, [], { changes: 1 });
+    const decrementCountStmt = mockStmt(null, [], { changes: 1 });
+    const unit = mockUnitSequence([
+      mockStmt({ lootboxId: 10, lootboxTypeId: 1, playerId: 1, openedAt: null, acquiredHow: "free" }),
+      mockStmt({ count: 0 }),
+      mockStmt(null, [
+        {
+          typeId: 22,
+          name: "Ember Stove",
+          rarity: "common",
+          imageUrl: "/assets/ember.png",
+          minHeat: 0.2,
+          maxHeat: 0.8,
+        },
+      ]),
+      insertStoveStmt,
+      openLootboxStmt,
+      insertDropStmt,
+      decrementCountStmt,
+    ]);
+    (unit.getLastRowId as jest.Mock)
+      .mockResolvedValueOnce(501)
+      .mockResolvedValueOnce(900);
+
+    const [success, result] = await new LootboxService(unit).openLootbox(10, 1);
+
+    expect(success).toBe(true);
+    expect(result).toEqual({
+      stoveId: 501,
+      stoveName: "Ember Stove",
+      rarity: "common",
+      imageUrl: "/assets/ember.png",
+      lootboxId: 10,
+    });
+    expect(insertStoveStmt.run).toHaveBeenCalledTimes(1);
+    expect(openLootboxStmt.run).toHaveBeenCalledTimes(1);
+    expect(insertDropStmt.run).toHaveBeenCalledTimes(1);
+    expect(decrementCountStmt.run).toHaveBeenCalledTimes(1);
+  });
+
+  test("a listed lootbox cannot be opened and no drop is created", async () => {
+    const insertStoveStmt = mockStmt(null, [], { changes: 1 });
+    const unit = mockUnitSequence([
+      mockStmt({ lootboxId: 10, lootboxTypeId: 1, playerId: 1, openedAt: null, acquiredHow: "free" }),
+      mockStmt({ count: 1 }),
+      insertStoveStmt,
+    ]);
+
+    const [success, result] = await new LootboxService(unit).openLootbox(10, 1);
+
+    expect(success).toBe(false);
+    expect(result).toBeNull();
+    expect(insertStoveStmt.run).not.toHaveBeenCalled();
+  });
+});

--- a/src/test/integrationTests/shop-purchase-flow.integration.test.ts
+++ b/src/test/integrationTests/shop-purchase-flow.integration.test.ts
@@ -1,0 +1,112 @@
+import { Unit } from "../../backend/utils/unit";
+
+jest.mock("../../backend/services/notification-service", () => ({
+  NotificationService: jest.fn(() => ({
+    create: jest.fn().mockResolvedValue([true, 1]),
+  })),
+}));
+
+jest.mock("../../backend/services/achievement-engine", () => ({
+  AchievementEngine: jest.fn(() => ({
+    checkShopAchievements: jest.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+import { ShopService } from "../../backend/services/shop-service";
+
+function mockStmt(getResult: unknown = null, allResult: unknown[] = [], runResult = { changes: 1 }) {
+  return {
+    get: jest.fn().mockResolvedValue(getResult),
+    all: jest.fn().mockResolvedValue(allResult),
+    run: jest.fn().mockResolvedValue(runResult),
+  };
+}
+
+function mockUnitSequence(stmts: ReturnType<typeof mockStmt>[]) {
+  let callIndex = 0;
+  return {
+    prepare: jest.fn().mockImplementation(() => {
+      const stmt = stmts[Math.min(callIndex, stmts.length - 1)];
+      callIndex++;
+      return stmt;
+    }),
+    getLastRowId: jest.fn().mockResolvedValue(11),
+  } as unknown as Unit;
+}
+
+describe("Shop purchase integration flow", () => {
+  test("buying a lootbox deducts coins, creates the lootbox, updates count, and logs the purchase", async () => {
+    const deductCoinsStmt = mockStmt(null, [], { changes: 1 });
+    const coinTransactionStmt = mockStmt(null, [], { changes: 1 });
+    const createLootboxStmt = mockStmt({ lootboxId: 77 });
+    const updateLootboxCountStmt = mockStmt(null, [], { changes: 1 });
+    const shopPurchaseStmt = mockStmt(null, [], { changes: 1 });
+    const unit = mockUnitSequence([
+      mockStmt({ playerId: 1, username: "buyer", coins: 1000, lootboxCount: 2 }),
+      mockStmt(null),
+      mockStmt({
+        listingId: 5,
+        itemType: "lootbox",
+        itemId: 1,
+        price: 300,
+        stock: -1,
+        name: "Standard Lootbox",
+        imageUrl: "assets/animation/chest-idle.gif",
+        rarity: "common",
+      }),
+      mockStmt(null, [{ lootboxTypeId: 1, dailyLimit: 2 }]),
+      mockStmt(null, []),
+      mockStmt({ dailyLimit: 2 }),
+      mockStmt({ count: 0 }),
+      deductCoinsStmt,
+      coinTransactionStmt,
+      createLootboxStmt,
+      updateLootboxCountStmt,
+      shopPurchaseStmt,
+    ]);
+
+    const result = await new ShopService(unit).purchaseItem(1, 5);
+
+    expect(result).toEqual({ success: true, itemId: 77 });
+    expect(deductCoinsStmt.run).toHaveBeenCalledTimes(1);
+    expect(coinTransactionStmt.run).toHaveBeenCalledTimes(1);
+    expect(createLootboxStmt.get).toHaveBeenCalledTimes(1);
+    expect(updateLootboxCountStmt.run).toHaveBeenCalledTimes(1);
+    expect(shopPurchaseStmt.run).toHaveBeenCalledTimes(1);
+    expect(unit.prepare).toHaveBeenCalledWith(
+      expect.stringContaining("UPDATE Player SET lootboxCount"),
+      { id: 1, lootboxCount: 3 }
+    );
+  });
+
+  test("daily lootbox limit stops the flow before coins are deducted", async () => {
+    const deductCoinsStmt = mockStmt(null, [], { changes: 1 });
+    const unit = mockUnitSequence([
+      mockStmt({ playerId: 1, username: "buyer", coins: 1000, lootboxCount: 2 }),
+      mockStmt(null),
+      mockStmt({
+        listingId: 5,
+        itemType: "lootbox",
+        itemId: 1,
+        price: 300,
+        stock: 0,
+        name: "Standard Lootbox",
+        imageUrl: "assets/animation/chest-idle.gif",
+        rarity: "common",
+      }),
+      mockStmt(null, [{ lootboxTypeId: 1, dailyLimit: 2 }]),
+      mockStmt(null, [{ listingId: 5, count: 2 }]),
+      mockStmt({ dailyLimit: 2 }),
+      mockStmt({ count: 2 }),
+      deductCoinsStmt,
+    ]);
+
+    const result = await new ShopService(unit).purchaseItem(1, 5);
+
+    expect(result).toEqual({
+      success: false,
+      error: "Daily purchase limit reached",
+    });
+    expect(deductCoinsStmt.run).not.toHaveBeenCalled();
+  });
+});

--- a/src/test/integrationTests/trade-offer-flow.integration.test.ts
+++ b/src/test/integrationTests/trade-offer-flow.integration.test.ts
@@ -1,0 +1,90 @@
+import { TradeOfferService } from "../../backend/services/trade-offer-service";
+import { Unit } from "../../backend/utils/unit";
+
+function mockStmt(getResult: unknown = null, allResult: unknown[] = [], runResult = { changes: 1 }) {
+  return {
+    get: jest.fn().mockResolvedValue(getResult),
+    all: jest.fn().mockResolvedValue(allResult),
+    run: jest.fn().mockResolvedValue(runResult),
+  };
+}
+
+function mockUnitSequence(stmts: ReturnType<typeof mockStmt>[]) {
+  let callIndex = 0;
+  return {
+    prepare: jest.fn().mockImplementation(() => {
+      const stmt = stmts[Math.min(callIndex, stmts.length - 1)];
+      callIndex++;
+      return stmt;
+    }),
+    getLastRowId: jest.fn().mockResolvedValue(1),
+  } as unknown as Unit;
+}
+
+describe("Trade offer integration flow", () => {
+  const message = {
+    messageId: 100,
+    senderId: 2,
+    receiverId: 1,
+    content: "Trade offer",
+    messageType: "trade_offer",
+    data: { itemType: "stove", itemId: 44, price: 250, status: "pending" },
+  };
+
+  test("accepting a stove trade transfers coins, transfers ownership, logs both coin transactions, and accepts the message", async () => {
+    const deductBuyerStmt = mockStmt(null, [], { changes: 1 });
+    const creditSellerStmt = mockStmt(null, [], { changes: 1 });
+    const updateStoveOwnerStmt = mockStmt(null, [], { changes: 1 });
+    const insertOwnershipStmt = mockStmt(null, [], { changes: 1 });
+    const buyerCoinTransactionStmt = mockStmt(null, [], { changes: 1 });
+    const sellerCoinTransactionStmt = mockStmt(null, [], { changes: 1 });
+    const updateMessageStmt = mockStmt(null, [], { changes: 1 });
+    const unit = mockUnitSequence([
+      mockStmt(message),
+      mockStmt({ currentOwnerId: 2 }),
+      mockStmt({ count: 0 }),
+      mockStmt({ playerId: 1, username: "buyer", coins: 1000 }),
+      mockStmt({ playerId: 2, username: "seller", coins: 50 }),
+      deductBuyerStmt,
+      creditSellerStmt,
+      updateStoveOwnerStmt,
+      insertOwnershipStmt,
+      buyerCoinTransactionStmt,
+      sellerCoinTransactionStmt,
+      updateMessageStmt,
+    ]);
+
+    const result = await new TradeOfferService(unit).acceptTradeOffer(100, 1);
+
+    expect(result).toEqual({ success: true, senderId: 2 });
+    expect(deductBuyerStmt.run).toHaveBeenCalledTimes(1);
+    expect(creditSellerStmt.run).toHaveBeenCalledTimes(1);
+    expect(updateStoveOwnerStmt.run).toHaveBeenCalledTimes(1);
+    expect(insertOwnershipStmt.run).toHaveBeenCalledTimes(1);
+    expect(buyerCoinTransactionStmt.run).toHaveBeenCalledTimes(1);
+    expect(sellerCoinTransactionStmt.run).toHaveBeenCalledTimes(1);
+    expect(updateMessageStmt.run).toHaveBeenCalledTimes(1);
+    expect(unit.prepare).toHaveBeenCalledWith(
+      expect.stringContaining("UPDATE ChatMessage SET data"),
+      { messageId: 100 }
+    );
+  });
+
+  test("an active marketplace listing blocks the trade before money moves", async () => {
+    const deductBuyerStmt = mockStmt(null, [], { changes: 1 });
+    const unit = mockUnitSequence([
+      mockStmt(message),
+      mockStmt({ currentOwnerId: 2 }),
+      mockStmt({ count: 1 }),
+      deductBuyerStmt,
+    ]);
+
+    const result = await new TradeOfferService(unit).acceptTradeOffer(100, 1);
+
+    expect(result).toEqual({
+      success: false,
+      error: "Item is currently listed for sale",
+    });
+    expect(deductBuyerStmt.run).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds router/API tests for auth, player, lootbox, ownership, shop, marketplace/listing, and trade flows

## Tests
- Jest API tests passed during setup