### PR TITLE
test: add game engine edge coverage

### DIFF
--- a/src/test/gameEngineTests/blackjack-edge-cases.test.ts
+++ b/src/test/gameEngineTests/blackjack-edge-cases.test.ts
@@ -1,0 +1,114 @@
+import { BlackJackEngine } from "../../backend/game-engines/blackjack-engine";
+import { BlackjackState } from "../../backend/game-logic/blackjack-types";
+import { RoomPlayerRow } from "../../shared/model";
+
+describe("BlackJack Engine edge cases", () => {
+  const engine = new BlackJackEngine();
+
+  const players: RoomPlayerRow[] = [
+    { roomPlayerId: "rp1", roomId: "r1", playerId: 1, username: "Alice", connectionState: "connected", seatIndex: 0 },
+    { roomPlayerId: "rp2", roomId: "r1", playerId: 2, username: "Bob", connectionState: "connected", seatIndex: 1 },
+  ];
+
+  function makeState(overrides: Partial<BlackjackState> = {}): BlackjackState {
+    return {
+      status: "active",
+      phase: "player_turn",
+      deck: ["2c", "3c", "4c", "5c", "6c"],
+      dealerHand: ["9h", "7d"],
+      players: [
+        {
+          playerId: 1,
+          username: "Alice",
+          activeTitle: null,
+          activeBanner: null,
+          hands: [["Ah", "Kd"]],
+          bets: [20],
+          stack: 980,
+          result: "blackjack",
+        },
+        {
+          playerId: 2,
+          username: "Bob",
+          activeTitle: null,
+          activeBanner: null,
+          hands: [["Th", "8d"]],
+          bets: [20],
+          stack: 980,
+          result: "playing",
+        },
+      ],
+      activePlayer: 2,
+      activeHandIndex: 0,
+      currentBet: 20,
+      log: [],
+      ...overrides,
+    };
+  }
+
+  test("natural blackjack pays 3:2 after another player finishes the hand", () => {
+    const result = engine.processAction(
+      makeState() as unknown as Record<string, unknown>,
+      { type: "stand" },
+      2
+    );
+
+    expect(result.valid).toBe(true);
+    const state = result.newFullState as unknown as BlackjackState;
+    const blackjackPlayer = state.players.find((p) => p.playerId === 1)!;
+
+    expect(state.phase).toBe("settled");
+    expect(blackjackPlayer.result).toBe("won");
+    expect(blackjackPlayer.stack).toBe(1030);
+    expect(state.winners).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          playerId: 1,
+          amount: 30,
+          handName: "Blackjack",
+        }),
+      ])
+    );
+  });
+
+  test("next hand action is rejected during active play", () => {
+    const state = makeState();
+    const result = engine.processAction(
+      state as unknown as Record<string, unknown>,
+      { type: "next_hand" },
+      2
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.errorMessage).toBe("Use resetForNextHand instead");
+    expect(result.newFullState).toBe(state);
+  });
+
+  test("reset keeps only players still present in the room", () => {
+    const state = makeState({
+      phase: "settled",
+      activePlayer: -1,
+      players: [
+        { ...makeState().players[0], stack: 1250, result: "won" },
+        { ...makeState().players[1], stack: 0, result: "lost" },
+      ],
+    });
+
+    const nextState = engine.resetForNextHand(
+      state as unknown as Record<string, unknown>,
+      [players[0]]
+    ) as unknown as BlackjackState;
+
+    expect(nextState.players).toHaveLength(1);
+    expect(nextState.players[0]).toEqual(
+      expect.objectContaining({
+        playerId: 1,
+        username: "Alice",
+        stack: 1250,
+        hands: [[]],
+        bets: [0],
+        result: "playing",
+      })
+    );
+  });
+});

--- a/src/test/gameEngineTests/poker-edge-cases.test.ts
+++ b/src/test/gameEngineTests/poker-edge-cases.test.ts
@@ -1,0 +1,120 @@
+import { PokerEngine } from "../../backend/game-engines/poker-engine";
+import { PokerState } from "../../backend/game-logic/poker-types";
+
+describe("PokerEngine edge cases", () => {
+  const engine = new PokerEngine();
+
+  function makeRiverState(overrides: Partial<PokerState> = {}): PokerState {
+    return {
+      status: "active",
+      phase: "river",
+      deck: ["2c", "3d", "4h"],
+      communityCards: ["Ah", "Kh", "Qh", "Jh", "2s"],
+      pots: [{ amount: 200, eligiblePlayers: [1, 2] }],
+      currentBet: 0,
+      dealerPosition: 0,
+      activePlayer: 1,
+      players: [
+        {
+          playerId: 1,
+          username: "Alice",
+          activeTitle: null,
+          activeBanner: null,
+          hand: ["Th", "3c"],
+          stack: 900,
+          bet: 0,
+          totalBet: 100,
+          folded: false,
+          allIn: false,
+        },
+        {
+          playerId: 2,
+          username: "Bob",
+          activeTitle: null,
+          activeBanner: null,
+          hand: ["As", "Ad"],
+          stack: 900,
+          bet: 0,
+          totalBet: 100,
+          folded: false,
+          allIn: false,
+        },
+      ],
+      playersToAct: [1],
+      log: [],
+      ...overrides,
+    };
+  }
+
+  test("river check resolves showdown and awards the pot to the best hand", () => {
+    const result = engine.processAction(
+      makeRiverState() as unknown as Record<string, unknown>,
+      { type: "check" },
+      1
+    );
+
+    expect(result.valid).toBe(true);
+    const state = result.newFullState as unknown as PokerState;
+
+    expect(state.phase).toBe("showdown");
+    expect(state.activePlayer).toBe(-1);
+    expect(state.players.find((p) => p.playerId === 1)?.stack).toBe(1100);
+    expect(state.players.find((p) => p.playerId === 2)?.stack).toBe(900);
+    expect(state.pots[0].amount).toBe(0);
+    expect(state.winners).toEqual([
+      { playerId: 1, amount: 200, handName: "Straight Flush" },
+    ]);
+  });
+
+  test("showdown player views reveal hands and include hand names", () => {
+    const state = engine.processAction(
+      makeRiverState() as unknown as Record<string, unknown>,
+      { type: "check" },
+      1
+    ).newFullState as unknown as PokerState;
+
+    const view = engine.getPlayerView(
+      state as unknown as Record<string, unknown>,
+      2
+    ) as unknown as { players: Array<{ playerId: number; hand: string[]; handName?: string }> };
+
+    expect(view.players.find((p) => p.playerId === 1)?.hand).toEqual(["Th", "3c"]);
+    expect(view.players.find((p) => p.playerId === 1)?.handName).toBe("Straight Flush");
+    expect(view.players.find((p) => p.playerId === 2)?.hand).toEqual(["As", "Ad"]);
+    expect(view.players.find((p) => p.playerId === 2)?.handName).toBe("Three of a Kind");
+  });
+
+  test("folded and all-in players cannot act even if state points at them", () => {
+    const foldedState = makeRiverState({
+      players: [
+        { ...makeRiverState().players[0], folded: true },
+        makeRiverState().players[1],
+      ],
+    });
+
+    const foldedResult = engine.processAction(
+      foldedState as unknown as Record<string, unknown>,
+      { type: "check" },
+      1
+    );
+
+    expect(foldedResult.valid).toBe(false);
+    expect(foldedResult.errorMessage).toBe("Player cannot act");
+
+    const allInState = makeRiverState({
+      players: [
+        { ...makeRiverState().players[0], allIn: true },
+        makeRiverState().players[1],
+      ],
+    });
+
+    const allInResult = engine.processAction(
+      allInState as unknown as Record<string, unknown>,
+      { type: "check" },
+      1
+    );
+
+    expect(allInResult.valid).toBe(false);
+    expect(allInResult.errorMessage).toBe("Player cannot act");
+  });
+});

--- a/src/test/gameEngineTests/roulette-edge-cases.test.ts
+++ b/src/test/gameEngineTests/roulette-edge-cases.test.ts
@@ -1,0 +1,102 @@
+import { RouletteEngine, RouletteState } from "../../backend/game-engines/roulette-engine";
+import { RoomPlayerRow } from "../../shared/model";
+
+describe("Roulette Engine edge cases", () => {
+  const engine = new RouletteEngine();
+
+  const players: RoomPlayerRow[] = [
+    { playerId: 1, username: "Alice", coins: 1000, activeTitle: null, activeBanner: null } as RoomPlayerRow,
+    { playerId: 2, username: "Bob", coins: 1000, activeTitle: null, activeBanner: null } as RoomPlayerRow,
+  ];
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function bet(
+    state: Record<string, unknown>,
+    betType: string,
+    amount = 10,
+    number?: number
+  ): Record<string, unknown> {
+    return engine.processAction(state, { type: "bet", betType, amount, number }, 1)
+      .newFullState;
+  }
+
+  test("controlled red odd low straight dozen and column bets pay correctly", () => {
+    jest.spyOn(Math, "random").mockReturnValue(7 / 37);
+    let state = engine.createInitialState(players);
+
+    state = bet(state, "red");
+    state = bet(state, "odd");
+    state = bet(state, "low");
+    state = bet(state, "straight", 10, 7);
+    state = bet(state, "dozen1");
+    state = bet(state, "column1");
+
+    const result = engine.processAction(state, { type: "spin" }, 1);
+
+    expect(result.valid).toBe(true);
+    const settled = result.newFullState as unknown as RouletteState;
+    const player = settled.players.find((p) => p.playerId === 1)!;
+
+    expect(settled.winningNumber).toBe(7);
+    expect(settled.winningColor).toBe("red");
+    expect(player.result).toBe("won");
+    expect(player.stack).toBe(1420);
+    expect(settled.winners).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ betType: "straight", amount: 350 }),
+        expect.objectContaining({ betType: "dozen1", amount: 20 }),
+        expect.objectContaining({ betType: "column1", amount: 20 }),
+      ])
+    );
+  });
+
+  test("zero only pays green straight bets and loses even-money outside bets", () => {
+    jest.spyOn(Math, "random").mockReturnValue(0);
+    let state = engine.createInitialState(players);
+
+    state = bet(state, "straight", 10, 0);
+    state = bet(state, "red");
+    state = bet(state, "black");
+    state = bet(state, "even");
+    state = bet(state, "odd");
+    state = bet(state, "high");
+    state = bet(state, "low");
+
+    const settled = engine.processAction(state, { type: "spin" }, 1)
+      .newFullState as unknown as RouletteState;
+    const player = settled.players.find((p) => p.playerId === 1)!;
+
+    expect(settled.winningNumber).toBe(0);
+    expect(settled.winningColor).toBe("green");
+    expect(player.result).toBe("won");
+    expect(player.stack).toBe(1290);
+    expect(settled.winners).toEqual([
+      { playerId: 1, amount: 350, betType: "straight" },
+    ]);
+  });
+
+  test("invalid bet type and out-of-range straight bets keep the original state", () => {
+    const state = engine.createInitialState(players);
+
+    const invalidType = engine.processAction(
+      state,
+      { type: "bet", amount: 10, betType: "split" },
+      1
+    );
+    const invalidNumber = engine.processAction(
+      state,
+      { type: "bet", amount: 10, betType: "straight", number: 37 },
+      1
+    );
+
+    expect(invalidType.valid).toBe(false);
+    expect(invalidType.errorMessage).toBe("Invalid bet type: split");
+    expect(invalidType.newFullState).toBe(state);
+    expect(invalidNumber.valid).toBe(false);
+    expect(invalidNumber.errorMessage).toBe("Straight bet requires a number 0-36");
+    expect(invalidNumber.newFullState).toBe(state);
+  });
+});

--- a/src/test/integrationTests/lootbox-opening-flow.integration.test.ts
+++ b/src/test/integrationTests/lootbox-opening-flow.integration.test.ts
@@ -1,0 +1,118 @@
+import { Unit } from "../../backend/utils/unit";
+
+jest.mock("../../backend/services/player-prestige-service", () => ({
+  PlayerPrestigeService: jest.fn(() => ({
+    addXP: jest.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+jest.mock("../../backend/services/achievement-engine", () => ({
+  AchievementEngine: jest.fn(() => ({
+    checkLootboxAchievements: jest.fn().mockResolvedValue(undefined),
+    checkWealthAchievements: jest.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+jest.mock("../../backend/services/pity-service", () => ({
+  PityService: jest.fn(() => ({
+    checkPity: jest.fn().mockResolvedValue(null),
+    resetCounter: jest.fn().mockResolvedValue(undefined),
+    incrementCounter: jest.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+jest.mock("../../backend/services/quest-service", () => ({
+  QuestService: jest.fn(() => ({
+    trackProgress: jest.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+import { LootboxService } from "../../backend/services/lootbox-service";
+
+function mockStmt(getResult: unknown = null, allResult: unknown[] = [], runResult = { changes: 1 }) {
+  return {
+    get: jest.fn().mockResolvedValue(getResult),
+    all: jest.fn().mockResolvedValue(allResult),
+    run: jest.fn().mockResolvedValue(runResult),
+  };
+}
+
+function mockUnitSequence(stmts: ReturnType<typeof mockStmt>[]) {
+  let callIndex = 0;
+  return {
+    prepare: jest.fn().mockImplementation(() => {
+      const stmt = stmts[Math.min(callIndex, stmts.length - 1)];
+      callIndex++;
+      return stmt;
+    }),
+    getLastRowId: jest.fn(),
+    savepoint: jest.fn().mockResolvedValue(undefined),
+    rollbackToSavepoint: jest.fn().mockResolvedValue(undefined),
+  } as unknown as Unit;
+}
+
+describe("Lootbox opening integration flow", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("opening an owned unlisted lootbox creates a stove, marks the box opened, creates a drop, and decrements count", async () => {
+    jest.spyOn(Math, "random").mockReturnValue(0);
+
+    const insertStoveStmt = mockStmt(null, [], { changes: 1 });
+    const openLootboxStmt = mockStmt(null, [], { changes: 1 });
+    const insertDropStmt = mockStmt(null, [], { changes: 1 });
+    const decrementCountStmt = mockStmt(null, [], { changes: 1 });
+    const unit = mockUnitSequence([
+      mockStmt({ lootboxId: 10, lootboxTypeId: 1, playerId: 1, openedAt: null, acquiredHow: "free" }),
+      mockStmt({ count: 0 }),
+      mockStmt(null, [
+        {
+          typeId: 22,
+          name: "Ember Stove",
+          rarity: "common",
+          imageUrl: "/assets/ember.png",
+          minHeat: 0.2,
+          maxHeat: 0.8,
+        },
+      ]),
+      insertStoveStmt,
+      openLootboxStmt,
+      insertDropStmt,
+      decrementCountStmt,
+    ]);
+    (unit.getLastRowId as jest.Mock)
+      .mockResolvedValueOnce(501)
+      .mockResolvedValueOnce(900);
+
+    const [success, result] = await new LootboxService(unit).openLootbox(10, 1);
+
+    expect(success).toBe(true);
+    expect(result).toEqual({
+      stoveId: 501,
+      stoveName: "Ember Stove",
+      rarity: "common",
+      imageUrl: "/assets/ember.png",
+      lootboxId: 10,
+    });
+    expect(insertStoveStmt.run).toHaveBeenCalledTimes(1);
+    expect(openLootboxStmt.run).toHaveBeenCalledTimes(1);
+    expect(insertDropStmt.run).toHaveBeenCalledTimes(1);
+    expect(decrementCountStmt.run).toHaveBeenCalledTimes(1);
+  });
+
+  test("a listed lootbox cannot be opened and no drop is created", async () => {
+    const insertStoveStmt = mockStmt(null, [], { changes: 1 });
+    const unit = mockUnitSequence([
+      mockStmt({ lootboxId: 10, lootboxTypeId: 1, playerId: 1, openedAt: null, acquiredHow: "free" }),
+      mockStmt({ count: 1 }),
+      insertStoveStmt,
+    ]);
+
+    const [success, result] = await new LootboxService(unit).openLootbox(10, 1);
+
+    expect(success).toBe(false);
+    expect(result).toBeNull();
+    expect(insertStoveStmt.run).not.toHaveBeenCalled();
+  });
+});

--- a/src/test/integrationTests/shop-purchase-flow.integration.test.ts
+++ b/src/test/integrationTests/shop-purchase-flow.integration.test.ts
@@ -1,0 +1,112 @@
+import { Unit } from "../../backend/utils/unit";
+
+jest.mock("../../backend/services/notification-service", () => ({
+  NotificationService: jest.fn(() => ({
+    create: jest.fn().mockResolvedValue([true, 1]),
+  })),
+}));
+
+jest.mock("../../backend/services/achievement-engine", () => ({
+  AchievementEngine: jest.fn(() => ({
+    checkShopAchievements: jest.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+import { ShopService } from "../../backend/services/shop-service";
+
+function mockStmt(getResult: unknown = null, allResult: unknown[] = [], runResult = { changes: 1 }) {
+  return {
+    get: jest.fn().mockResolvedValue(getResult),
+    all: jest.fn().mockResolvedValue(allResult),
+    run: jest.fn().mockResolvedValue(runResult),
+  };
+}
+
+function mockUnitSequence(stmts: ReturnType<typeof mockStmt>[]) {
+  let callIndex = 0;
+  return {
+    prepare: jest.fn().mockImplementation(() => {
+      const stmt = stmts[Math.min(callIndex, stmts.length - 1)];
+      callIndex++;
+      return stmt;
+    }),
+    getLastRowId: jest.fn().mockResolvedValue(11),
+  } as unknown as Unit;
+}
+
+describe("Shop purchase integration flow", () => {
+  test("buying a lootbox deducts coins, creates the lootbox, updates count, and logs the purchase", async () => {
+    const deductCoinsStmt = mockStmt(null, [], { changes: 1 });
+    const coinTransactionStmt = mockStmt(null, [], { changes: 1 });
+    const createLootboxStmt = mockStmt({ lootboxId: 77 });
+    const updateLootboxCountStmt = mockStmt(null, [], { changes: 1 });
+    const shopPurchaseStmt = mockStmt(null, [], { changes: 1 });
+    const unit = mockUnitSequence([
+      mockStmt({ playerId: 1, username: "buyer", coins: 1000, lootboxCount: 2 }),
+      mockStmt(null),
+      mockStmt({
+        listingId: 5,
+        itemType: "lootbox",
+        itemId: 1,
+        price: 300,
+        stock: -1,
+        name: "Standard Lootbox",
+        imageUrl: "assets/animation/chest-idle.gif",
+        rarity: "common",
+      }),
+      mockStmt(null, [{ lootboxTypeId: 1, dailyLimit: 2 }]),
+      mockStmt(null, []),
+      mockStmt({ dailyLimit: 2 }),
+      mockStmt({ count: 0 }),
+      deductCoinsStmt,
+      coinTransactionStmt,
+      createLootboxStmt,
+      updateLootboxCountStmt,
+      shopPurchaseStmt,
+    ]);
+
+    const result = await new ShopService(unit).purchaseItem(1, 5);
+
+    expect(result).toEqual({ success: true, itemId: 77 });
+    expect(deductCoinsStmt.run).toHaveBeenCalledTimes(1);
+    expect(coinTransactionStmt.run).toHaveBeenCalledTimes(1);
+    expect(createLootboxStmt.get).toHaveBeenCalledTimes(1);
+    expect(updateLootboxCountStmt.run).toHaveBeenCalledTimes(1);
+    expect(shopPurchaseStmt.run).toHaveBeenCalledTimes(1);
+    expect(unit.prepare).toHaveBeenCalledWith(
+      expect.stringContaining("UPDATE Player SET lootboxCount"),
+      { id: 1, lootboxCount: 3 }
+    );
+  });
+
+  test("daily lootbox limit stops the flow before coins are deducted", async () => {
+    const deductCoinsStmt = mockStmt(null, [], { changes: 1 });
+    const unit = mockUnitSequence([
+      mockStmt({ playerId: 1, username: "buyer", coins: 1000, lootboxCount: 2 }),
+      mockStmt(null),
+      mockStmt({
+        listingId: 5,
+        itemType: "lootbox",
+        itemId: 1,
+        price: 300,
+        stock: 0,
+        name: "Standard Lootbox",
+        imageUrl: "assets/animation/chest-idle.gif",
+        rarity: "common",
+      }),
+      mockStmt(null, [{ lootboxTypeId: 1, dailyLimit: 2 }]),
+      mockStmt(null, [{ listingId: 5, count: 2 }]),
+      mockStmt({ dailyLimit: 2 }),
+      mockStmt({ count: 2 }),
+      deductCoinsStmt,
+    ]);
+
+    const result = await new ShopService(unit).purchaseItem(1, 5);
+
+    expect(result).toEqual({
+      success: false,
+      error: "Daily purchase limit reached",
+    });
+    expect(deductCoinsStmt.run).not.toHaveBeenCalled();
+  });
+});

--- a/src/test/integrationTests/trade-offer-flow.integration.test.ts
+++ b/src/test/integrationTests/trade-offer-flow.integration.test.ts
@@ -1,0 +1,90 @@
+import { TradeOfferService } from "../../backend/services/trade-offer-service";
+import { Unit } from "../../backend/utils/unit";
+
+function mockStmt(getResult: unknown = null, allResult: unknown[] = [], runResult = { changes: 1 }) {
+  return {
+    get: jest.fn().mockResolvedValue(getResult),
+    all: jest.fn().mockResolvedValue(allResult),
+    run: jest.fn().mockResolvedValue(runResult),
+  };
+}
+
+function mockUnitSequence(stmts: ReturnType<typeof mockStmt>[]) {
+  let callIndex = 0;
+  return {
+    prepare: jest.fn().mockImplementation(() => {
+      const stmt = stmts[Math.min(callIndex, stmts.length - 1)];
+      callIndex++;
+      return stmt;
+    }),
+    getLastRowId: jest.fn().mockResolvedValue(1),
+  } as unknown as Unit;
+}
+
+describe("Trade offer integration flow", () => {
+  const message = {
+    messageId: 100,
+    senderId: 2,
+    receiverId: 1,
+    content: "Trade offer",
+    messageType: "trade_offer",
+    data: { itemType: "stove", itemId: 44, price: 250, status: "pending" },
+  };
+
+  test("accepting a stove trade transfers coins, transfers ownership, logs both coin transactions, and accepts the message", async () => {
+    const deductBuyerStmt = mockStmt(null, [], { changes: 1 });
+    const creditSellerStmt = mockStmt(null, [], { changes: 1 });
+    const updateStoveOwnerStmt = mockStmt(null, [], { changes: 1 });
+    const insertOwnershipStmt = mockStmt(null, [], { changes: 1 });
+    const buyerCoinTransactionStmt = mockStmt(null, [], { changes: 1 });
+    const sellerCoinTransactionStmt = mockStmt(null, [], { changes: 1 });
+    const updateMessageStmt = mockStmt(null, [], { changes: 1 });
+    const unit = mockUnitSequence([
+      mockStmt(message),
+      mockStmt({ currentOwnerId: 2 }),
+      mockStmt({ count: 0 }),
+      mockStmt({ playerId: 1, username: "buyer", coins: 1000 }),
+      mockStmt({ playerId: 2, username: "seller", coins: 50 }),
+      deductBuyerStmt,
+      creditSellerStmt,
+      updateStoveOwnerStmt,
+      insertOwnershipStmt,
+      buyerCoinTransactionStmt,
+      sellerCoinTransactionStmt,
+      updateMessageStmt,
+    ]);
+
+    const result = await new TradeOfferService(unit).acceptTradeOffer(100, 1);
+
+    expect(result).toEqual({ success: true, senderId: 2 });
+    expect(deductBuyerStmt.run).toHaveBeenCalledTimes(1);
+    expect(creditSellerStmt.run).toHaveBeenCalledTimes(1);
+    expect(updateStoveOwnerStmt.run).toHaveBeenCalledTimes(1);
+    expect(insertOwnershipStmt.run).toHaveBeenCalledTimes(1);
+    expect(buyerCoinTransactionStmt.run).toHaveBeenCalledTimes(1);
+    expect(sellerCoinTransactionStmt.run).toHaveBeenCalledTimes(1);
+    expect(updateMessageStmt.run).toHaveBeenCalledTimes(1);
+    expect(unit.prepare).toHaveBeenCalledWith(
+      expect.stringContaining("UPDATE ChatMessage SET data"),
+      { messageId: 100 }
+    );
+  });
+
+  test("an active marketplace listing blocks the trade before money moves", async () => {
+    const deductBuyerStmt = mockStmt(null, [], { changes: 1 });
+    const unit = mockUnitSequence([
+      mockStmt(message),
+      mockStmt({ currentOwnerId: 2 }),
+      mockStmt({ count: 1 }),
+      deductBuyerStmt,
+    ]);
+
+    const result = await new TradeOfferService(unit).acceptTradeOffer(100, 1);
+
+    expect(result).toEqual({
+      success: false,
+      error: "Item is currently listed for sale",
+    });
+    expect(deductBuyerStmt.run).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds blackjack, poker, and roulette edge-case coverage
- Includes deterministic roulette spin assertions and settlement/view edge cases

## Tests
- Jest game engine tests passed during setup