### PR TITLE
test: add integration flow coverage

### DIFF
--- a/src/test/integrationTests/lootbox-opening-flow.integration.test.ts
+++ b/src/test/integrationTests/lootbox-opening-flow.integration.test.ts
@@ -1,0 +1,118 @@
+import { Unit } from "../../backend/utils/unit";
+
+jest.mock("../../backend/services/player-prestige-service", () => ({
+  PlayerPrestigeService: jest.fn(() => ({
+    addXP: jest.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+jest.mock("../../backend/services/achievement-engine", () => ({
+  AchievementEngine: jest.fn(() => ({
+    checkLootboxAchievements: jest.fn().mockResolvedValue(undefined),
+    checkWealthAchievements: jest.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+jest.mock("../../backend/services/pity-service", () => ({
+  PityService: jest.fn(() => ({
+    checkPity: jest.fn().mockResolvedValue(null),
+    resetCounter: jest.fn().mockResolvedValue(undefined),
+    incrementCounter: jest.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+jest.mock("../../backend/services/quest-service", () => ({
+  QuestService: jest.fn(() => ({
+    trackProgress: jest.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+import { LootboxService } from "../../backend/services/lootbox-service";
+
+function mockStmt(getResult: unknown = null, allResult: unknown[] = [], runResult = { changes: 1 }) {
+  return {
+    get: jest.fn().mockResolvedValue(getResult),
+    all: jest.fn().mockResolvedValue(allResult),
+    run: jest.fn().mockResolvedValue(runResult),
+  };
+}
+
+function mockUnitSequence(stmts: ReturnType<typeof mockStmt>[]) {
+  let callIndex = 0;
+  return {
+    prepare: jest.fn().mockImplementation(() => {
+      const stmt = stmts[Math.min(callIndex, stmts.length - 1)];
+      callIndex++;
+      return stmt;
+    }),
+    getLastRowId: jest.fn(),
+    savepoint: jest.fn().mockResolvedValue(undefined),
+    rollbackToSavepoint: jest.fn().mockResolvedValue(undefined),
+  } as unknown as Unit;
+}
+
+describe("Lootbox opening integration flow", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("opening an owned unlisted lootbox creates a stove, marks the box opened, creates a drop, and decrements count", async () => {
+    jest.spyOn(Math, "random").mockReturnValue(0);
+
+    const insertStoveStmt = mockStmt(null, [], { changes: 1 });
+    const openLootboxStmt = mockStmt(null, [], { changes: 1 });
+    const insertDropStmt = mockStmt(null, [], { changes: 1 });
+    const decrementCountStmt = mockStmt(null, [], { changes: 1 });
+    const unit = mockUnitSequence([
+      mockStmt({ lootboxId: 10, lootboxTypeId: 1, playerId: 1, openedAt: null, acquiredHow: "free" }),
+      mockStmt({ count: 0 }),
+      mockStmt(null, [
+        {
+          typeId: 22,
+          name: "Ember Stove",
+          rarity: "common",
+          imageUrl: "/assets/ember.png",
+          minHeat: 0.2,
+          maxHeat: 0.8,
+        },
+      ]),
+      insertStoveStmt,
+      openLootboxStmt,
+      insertDropStmt,
+      decrementCountStmt,
+    ]);
+    (unit.getLastRowId as jest.Mock)
+      .mockResolvedValueOnce(501)
+      .mockResolvedValueOnce(900);
+
+    const [success, result] = await new LootboxService(unit).openLootbox(10, 1);
+
+    expect(success).toBe(true);
+    expect(result).toEqual({
+      stoveId: 501,
+      stoveName: "Ember Stove",
+      rarity: "common",
+      imageUrl: "/assets/ember.png",
+      lootboxId: 10,
+    });
+    expect(insertStoveStmt.run).toHaveBeenCalledTimes(1);
+    expect(openLootboxStmt.run).toHaveBeenCalledTimes(1);
+    expect(insertDropStmt.run).toHaveBeenCalledTimes(1);
+    expect(decrementCountStmt.run).toHaveBeenCalledTimes(1);
+  });
+
+  test("a listed lootbox cannot be opened and no drop is created", async () => {
+    const insertStoveStmt = mockStmt(null, [], { changes: 1 });
+    const unit = mockUnitSequence([
+      mockStmt({ lootboxId: 10, lootboxTypeId: 1, playerId: 1, openedAt: null, acquiredHow: "free" }),
+      mockStmt({ count: 1 }),
+      insertStoveStmt,
+    ]);
+
+    const [success, result] = await new LootboxService(unit).openLootbox(10, 1);
+
+    expect(success).toBe(false);
+    expect(result).toBeNull();
+    expect(insertStoveStmt.run).not.toHaveBeenCalled();
+  });
+});

--- a/src/test/integrationTests/shop-purchase-flow.integration.test.ts
+++ b/src/test/integrationTests/shop-purchase-flow.integration.test.ts
@@ -1,0 +1,112 @@
+import { Unit } from "../../backend/utils/unit";
+
+jest.mock("../../backend/services/notification-service", () => ({
+  NotificationService: jest.fn(() => ({
+    create: jest.fn().mockResolvedValue([true, 1]),
+  })),
+}));
+
+jest.mock("../../backend/services/achievement-engine", () => ({
+  AchievementEngine: jest.fn(() => ({
+    checkShopAchievements: jest.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+import { ShopService } from "../../backend/services/shop-service";
+
+function mockStmt(getResult: unknown = null, allResult: unknown[] = [], runResult = { changes: 1 }) {
+  return {
+    get: jest.fn().mockResolvedValue(getResult),
+    all: jest.fn().mockResolvedValue(allResult),
+    run: jest.fn().mockResolvedValue(runResult),
+  };
+}
+
+function mockUnitSequence(stmts: ReturnType<typeof mockStmt>[]) {
+  let callIndex = 0;
+  return {
+    prepare: jest.fn().mockImplementation(() => {
+      const stmt = stmts[Math.min(callIndex, stmts.length - 1)];
+      callIndex++;
+      return stmt;
+    }),
+    getLastRowId: jest.fn().mockResolvedValue(11),
+  } as unknown as Unit;
+}
+
+describe("Shop purchase integration flow", () => {
+  test("buying a lootbox deducts coins, creates the lootbox, updates count, and logs the purchase", async () => {
+    const deductCoinsStmt = mockStmt(null, [], { changes: 1 });
+    const coinTransactionStmt = mockStmt(null, [], { changes: 1 });
+    const createLootboxStmt = mockStmt({ lootboxId: 77 });
+    const updateLootboxCountStmt = mockStmt(null, [], { changes: 1 });
+    const shopPurchaseStmt = mockStmt(null, [], { changes: 1 });
+    const unit = mockUnitSequence([
+      mockStmt({ playerId: 1, username: "buyer", coins: 1000, lootboxCount: 2 }),
+      mockStmt(null),
+      mockStmt({
+        listingId: 5,
+        itemType: "lootbox",
+        itemId: 1,
+        price: 300,
+        stock: -1,
+        name: "Standard Lootbox",
+        imageUrl: "assets/animation/chest-idle.gif",
+        rarity: "common",
+      }),
+      mockStmt(null, [{ lootboxTypeId: 1, dailyLimit: 2 }]),
+      mockStmt(null, []),
+      mockStmt({ dailyLimit: 2 }),
+      mockStmt({ count: 0 }),
+      deductCoinsStmt,
+      coinTransactionStmt,
+      createLootboxStmt,
+      updateLootboxCountStmt,
+      shopPurchaseStmt,
+    ]);
+
+    const result = await new ShopService(unit).purchaseItem(1, 5);
+
+    expect(result).toEqual({ success: true, itemId: 77 });
+    expect(deductCoinsStmt.run).toHaveBeenCalledTimes(1);
+    expect(coinTransactionStmt.run).toHaveBeenCalledTimes(1);
+    expect(createLootboxStmt.get).toHaveBeenCalledTimes(1);
+    expect(updateLootboxCountStmt.run).toHaveBeenCalledTimes(1);
+    expect(shopPurchaseStmt.run).toHaveBeenCalledTimes(1);
+    expect(unit.prepare).toHaveBeenCalledWith(
+      expect.stringContaining("UPDATE Player SET lootboxCount"),
+      { id: 1, lootboxCount: 3 }
+    );
+  });
+
+  test("daily lootbox limit stops the flow before coins are deducted", async () => {
+    const deductCoinsStmt = mockStmt(null, [], { changes: 1 });
+    const unit = mockUnitSequence([
+      mockStmt({ playerId: 1, username: "buyer", coins: 1000, lootboxCount: 2 }),
+      mockStmt(null),
+      mockStmt({
+        listingId: 5,
+        itemType: "lootbox",
+        itemId: 1,
+        price: 300,
+        stock: 0,
+        name: "Standard Lootbox",
+        imageUrl: "assets/animation/chest-idle.gif",
+        rarity: "common",
+      }),
+      mockStmt(null, [{ lootboxTypeId: 1, dailyLimit: 2 }]),
+      mockStmt(null, [{ listingId: 5, count: 2 }]),
+      mockStmt({ dailyLimit: 2 }),
+      mockStmt({ count: 2 }),
+      deductCoinsStmt,
+    ]);
+
+    const result = await new ShopService(unit).purchaseItem(1, 5);
+
+    expect(result).toEqual({
+      success: false,
+      error: "Daily purchase limit reached",
+    });
+    expect(deductCoinsStmt.run).not.toHaveBeenCalled();
+  });
+});

--- a/src/test/integrationTests/trade-offer-flow.integration.test.ts
+++ b/src/test/integrationTests/trade-offer-flow.integration.test.ts
@@ -1,0 +1,90 @@
+import { TradeOfferService } from "../../backend/services/trade-offer-service";
+import { Unit } from "../../backend/utils/unit";
+
+function mockStmt(getResult: unknown = null, allResult: unknown[] = [], runResult = { changes: 1 }) {
+  return {
+    get: jest.fn().mockResolvedValue(getResult),
+    all: jest.fn().mockResolvedValue(allResult),
+    run: jest.fn().mockResolvedValue(runResult),
+  };
+}
+
+function mockUnitSequence(stmts: ReturnType<typeof mockStmt>[]) {
+  let callIndex = 0;
+  return {
+    prepare: jest.fn().mockImplementation(() => {
+      const stmt = stmts[Math.min(callIndex, stmts.length - 1)];
+      callIndex++;
+      return stmt;
+    }),
+    getLastRowId: jest.fn().mockResolvedValue(1),
+  } as unknown as Unit;
+}
+
+describe("Trade offer integration flow", () => {
+  const message = {
+    messageId: 100,
+    senderId: 2,
+    receiverId: 1,
+    content: "Trade offer",
+    messageType: "trade_offer",
+    data: { itemType: "stove", itemId: 44, price: 250, status: "pending" },
+  };
+
+  test("accepting a stove trade transfers coins, transfers ownership, logs both coin transactions, and accepts the message", async () => {
+    const deductBuyerStmt = mockStmt(null, [], { changes: 1 });
+    const creditSellerStmt = mockStmt(null, [], { changes: 1 });
+    const updateStoveOwnerStmt = mockStmt(null, [], { changes: 1 });
+    const insertOwnershipStmt = mockStmt(null, [], { changes: 1 });
+    const buyerCoinTransactionStmt = mockStmt(null, [], { changes: 1 });
+    const sellerCoinTransactionStmt = mockStmt(null, [], { changes: 1 });
+    const updateMessageStmt = mockStmt(null, [], { changes: 1 });
+    const unit = mockUnitSequence([
+      mockStmt(message),
+      mockStmt({ currentOwnerId: 2 }),
+      mockStmt({ count: 0 }),
+      mockStmt({ playerId: 1, username: "buyer", coins: 1000 }),
+      mockStmt({ playerId: 2, username: "seller", coins: 50 }),
+      deductBuyerStmt,
+      creditSellerStmt,
+      updateStoveOwnerStmt,
+      insertOwnershipStmt,
+      buyerCoinTransactionStmt,
+      sellerCoinTransactionStmt,
+      updateMessageStmt,
+    ]);
+
+    const result = await new TradeOfferService(unit).acceptTradeOffer(100, 1);
+
+    expect(result).toEqual({ success: true, senderId: 2 });
+    expect(deductBuyerStmt.run).toHaveBeenCalledTimes(1);
+    expect(creditSellerStmt.run).toHaveBeenCalledTimes(1);
+    expect(updateStoveOwnerStmt.run).toHaveBeenCalledTimes(1);
+    expect(insertOwnershipStmt.run).toHaveBeenCalledTimes(1);
+    expect(buyerCoinTransactionStmt.run).toHaveBeenCalledTimes(1);
+    expect(sellerCoinTransactionStmt.run).toHaveBeenCalledTimes(1);
+    expect(updateMessageStmt.run).toHaveBeenCalledTimes(1);
+    expect(unit.prepare).toHaveBeenCalledWith(
+      expect.stringContaining("UPDATE ChatMessage SET data"),
+      { messageId: 100 }
+    );
+  });
+
+  test("an active marketplace listing blocks the trade before money moves", async () => {
+    const deductBuyerStmt = mockStmt(null, [], { changes: 1 });
+    const unit = mockUnitSequence([
+      mockStmt(message),
+      mockStmt({ currentOwnerId: 2 }),
+      mockStmt({ count: 1 }),
+      deductBuyerStmt,
+    ]);
+
+    const result = await new TradeOfferService(unit).acceptTradeOffer(100, 1);
+
+    expect(result).toEqual({
+      success: false,
+      error: "Item is currently listed for sale",
+    });
+    expect(deductBuyerStmt.run).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds integration flow tests for shop purchases, lootbox opening, and trade offer acceptance
- Keeps DB-dependent WebSocket integration outside this PR stack

## Tests
- Stable backend Jest suite passed with these integration flow tests during setup