### PR TITLE
test: add websocket and frontend coverage

### DIFF
--- a/src/frontend/src/app/core/services/theme.service.spec.ts
+++ b/src/frontend/src/app/core/services/theme.service.spec.ts
@@ -1,0 +1,75 @@
+import { TestBed } from '@angular/core/testing';
+import { ThemeService } from './theme.service';
+
+describe('ThemeService', () => {
+  let mediaQueryListeners: Array<(event: MediaQueryListEvent) => void>;
+  let prefersDark = false;
+
+  beforeEach(() => {
+    localStorage.clear();
+    document.body.classList.remove('theme-light', 'theme-dark');
+    document.documentElement.removeAttribute('data-theme');
+    mediaQueryListeners = [];
+    prefersDark = false;
+
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: vi.fn(() => ({
+      matches: prefersDark,
+      media: '(prefers-color-scheme: dark)',
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn((_type, listener) => {
+        mediaQueryListeners.push(listener as (event: MediaQueryListEvent) => void);
+      }),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+      } as unknown as MediaQueryList)),
+    });
+
+    TestBed.configureTestingModule({});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    TestBed.resetTestingModule();
+  });
+
+  it('defaults to dark theme and stores it when no saved theme exists', () => {
+    const service = TestBed.inject(ThemeService);
+
+    expect(service.getCurrentTheme()).toBe('dark');
+    expect(localStorage.getItem('ember-theme')).toBe('dark');
+    expect(document.body.classList.contains('theme-dark')).toBe(true);
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+  });
+
+  it('applies and persists a selected light theme', () => {
+    const service = TestBed.inject(ThemeService);
+
+    service.setTheme('light');
+
+    expect(service.getCurrentTheme()).toBe('light');
+    expect(localStorage.getItem('ember-theme')).toBe('light');
+    expect(document.body.classList.contains('theme-light')).toBe(true);
+    expect(document.body.classList.contains('theme-dark')).toBe(false);
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+  });
+
+  it('resolves system theme from matchMedia and responds to system changes', () => {
+    const service = TestBed.inject(ThemeService);
+    prefersDark = false;
+
+    service.setTheme('system');
+
+    expect(document.body.classList.contains('theme-light')).toBe(true);
+    prefersDark = true;
+    mediaQueryListeners.forEach(listener => listener({ matches: true } as MediaQueryListEvent));
+
+    expect(service.getCurrentTheme()).toBe('system');
+    expect(document.body.classList.contains('theme-dark')).toBe(true);
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+  });
+});

--- a/src/frontend/src/app/core/services/websocket.service.spec.ts
+++ b/src/frontend/src/app/core/services/websocket.service.spec.ts
@@ -1,0 +1,156 @@
+import { TestBed } from '@angular/core/testing';
+import { AuthService } from './auth.service';
+import { WebSocketService } from './websocket.service';
+
+class FakeWebSocket {
+  static readonly OPEN = 1;
+  static instances: FakeWebSocket[] = [];
+
+  readyState = FakeWebSocket.OPEN;
+  sent: string[] = [];
+  onopen: (() => void) | null = null;
+  onmessage: ((event: MessageEvent<string>) => void) | null = null;
+  onclose: ((event: CloseEvent) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+
+  constructor(
+    public readonly url: string,
+    public readonly protocol: string
+  ) {
+    FakeWebSocket.instances.push(this);
+  }
+
+  send(message: string): void {
+    this.sent.push(message);
+  }
+
+  close(): void {
+    this.onclose?.({ code: 1000 } as CloseEvent);
+  }
+}
+
+describe('WebSocketService', () => {
+  let authService: {
+    getSessionId: ReturnType<typeof vi.fn>;
+    getCurrentUser: ReturnType<typeof vi.fn>;
+    patchCurrentUserCoins: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    FakeWebSocket.instances = [];
+    vi.stubGlobal('WebSocket', FakeWebSocket);
+    authService = {
+      getSessionId: vi.fn().mockReturnValue('session-1'),
+      getCurrentUser: vi.fn().mockReturnValue({ playerId: 1, coins: 1000 }),
+      patchCurrentUserCoins: vi.fn(),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        WebSocketService,
+        { provide: AuthService, useValue: authService },
+      ],
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    TestBed.resetTestingModule();
+  });
+
+  function connectOpen(service: WebSocketService): FakeWebSocket {
+    service.connect();
+    const socket = FakeWebSocket.instances[0];
+    socket.onopen?.();
+    return socket;
+  }
+
+  it('opens a socket using the current session id as the subprotocol', () => {
+    const service = TestBed.inject(WebSocketService);
+
+    service.connect();
+
+    const socket = FakeWebSocket.instances[0];
+    expect(socket.url).toBe(`${window.location.protocol === 'https:' ? 'wss:' : 'ws:'}//${window.location.host}/ws`);
+    expect(socket.protocol).toBe('session-1');
+    expect(service.connectionState()).toBe('connecting');
+
+    socket.onopen?.();
+    expect(service.connectionState()).toBe('open');
+    expect(service.lastError()).toBeNull();
+  });
+
+  it('does not connect when there is no session id', () => {
+    authService.getSessionId.mockReturnValue(null);
+    const service = TestBed.inject(WebSocketService);
+
+    service.connect();
+
+    expect(FakeWebSocket.instances).toHaveLength(0);
+    expect(service.connectionState()).toBe('closed');
+  });
+
+  it('sends room and gameplay messages with increasing sequence numbers', () => {
+    const service = TestBed.inject(WebSocketService);
+    const socket = connectOpen(service);
+
+    service.joinRoom('room-1');
+    service.sendStartGame();
+    service.sendAction('hit', { handIndex: 0 });
+    service.requestSync();
+    service.leaveRoom();
+
+    const messages = socket.sent.map(msg => JSON.parse(msg));
+    expect(messages.map(msg => msg.type)).toEqual([
+      'join_room',
+      'start_game',
+      'player_action',
+      'request_sync',
+      'leave_room',
+    ]);
+    expect(messages.map(msg => msg.sequenceNumber)).toEqual([1, 2, 3, 4, 5]);
+    expect(messages[2].payload).toEqual({
+      roomId: 'room-1',
+      actionType: 'hit',
+      actionData: { handIndex: 0 },
+      expectedVersion: 0,
+    });
+  });
+
+  it('updates local state and header coins from state_update messages', () => {
+    const service = TestBed.inject(WebSocketService);
+    const socket = connectOpen(service);
+
+    socket.onmessage?.({
+      data: JSON.stringify({
+        type: 'state_update',
+        payload: {
+          version: 9,
+          stateBlob: {
+            players: [
+              { playerId: 1, username: 'Alice', stack: 850, seatIndex: 0, connectionState: 'connected' },
+              { playerId: 2, username: 'Bob', stack: 1200, seatIndex: 1, connectionState: 'connected' },
+            ],
+          },
+        },
+      }),
+    } as MessageEvent<string>);
+
+    expect(service.currentVersion()).toBe(9);
+    expect(service.playersInRoom()).toHaveLength(2);
+    expect(authService.patchCurrentUserCoins).toHaveBeenCalledWith(850);
+  });
+
+  it('stores errors, chat messages, and trade offer updates from server messages', () => {
+    const service = TestBed.inject(WebSocketService);
+    const socket = connectOpen(service);
+
+    socket.onmessage?.({ data: JSON.stringify({ type: 'error', payload: { code: 'RATE_LIMITED', message: 'Too many messages' } }) } as MessageEvent<string>);
+    socket.onmessage?.({ data: JSON.stringify({ type: 'chat_message', payload: { messageId: 5, content: 'hello' } }) } as MessageEvent<string>);
+    socket.onmessage?.({ data: JSON.stringify({ type: 'trade_offer_update', payload: { messageId: 7, status: 'accepted' } }) } as MessageEvent<string>);
+
+    expect(service.lastError()).toEqual({ code: 'RATE_LIMITED', message: 'Too many messages' });
+    expect(service.incomingChatMessage()).toEqual({ messageId: 5, content: 'hello' });
+    expect(service.incomingTradeUpdate()).toEqual({ messageId: 7, status: 'accepted' });
+  });
+});

--- a/src/frontend/src/app/features/auth/pages/login/login.component.spec.ts
+++ b/src/frontend/src/app/features/auth/pages/login/login.component.spec.ts
@@ -1,18 +1,53 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { AuthService } from '@core/services/auth.service';
+import { BehaviorTrackerService } from '@core/services/behavior-tracker.service';
+import { TurnstileService } from '@core/services/turnstile.service';
 
-import { Login } from './login';
+import { LoginComponent } from './login.component';
 
-describe('Login', () => {
-  let component: Login;
-  let fixture: ComponentFixture<Login>;
+describe('LoginComponent', () => {
+  let component: LoginComponent;
+  let fixture: ComponentFixture<LoginComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [Login]
+      imports: [LoginComponent],
+      providers: [
+        provideRouter([]),
+        {
+          provide: AuthService,
+          useValue: {
+            getOAuthStatus: vi.fn().mockResolvedValue({ google: false, github: false }),
+            getPowChallenge: vi.fn().mockResolvedValue({ challenge: 'abc', difficulty: 0 }),
+            solvePow: vi.fn().mockResolvedValue('0'),
+            login: vi.fn(),
+            verify2FA: vi.fn(),
+            cancel2FA: vi.fn(),
+          },
+        },
+        {
+          provide: TurnstileService,
+          useValue: {
+            initialize: vi.fn().mockResolvedValue(undefined),
+            render: vi.fn().mockReturnValue('widget-1'),
+            isReady: vi.fn().mockReturnValue(true),
+            getToken: vi.fn().mockReturnValue('token'),
+            reset: vi.fn(),
+          },
+        },
+        {
+          provide: BehaviorTrackerService,
+          useValue: {
+            startTracking: vi.fn(),
+            getToken: vi.fn().mockReturnValue('behavior-token'),
+          },
+        },
+      ],
     })
     .compileComponents();
 
-    fixture = TestBed.createComponent(Login);
+    fixture = TestBed.createComponent(LoginComponent);
     component = fixture.componentInstance;
     await fixture.whenStable();
   });

--- a/src/frontend/src/app/features/marketplace/marketplace.component.spec.ts
+++ b/src/frontend/src/app/features/marketplace/marketplace.component.spec.ts
@@ -1,18 +1,69 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { of } from 'rxjs';
+import { AuthService } from '@core/services/auth.service';
+import { ListingService } from '@core/services/listing.service';
+import { LootboxService } from '@core/services/lootbox.service';
+import { PriceHistoryService } from '@core/services/price-history.service';
+import { StoveService } from '@core/services/stove.service';
+import { TradeService } from '@core/services/trade.service';
 
-import { Marketplace } from './marketplace';
+import { MarketplaceComponent } from './marketplace.component';
 
-describe('Marketplace', () => {
-  let component: Marketplace;
-  let fixture: ComponentFixture<Marketplace>;
+describe('MarketplaceComponent', () => {
+  let component: MarketplaceComponent;
+  let fixture: ComponentFixture<MarketplaceComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [Marketplace]
+      imports: [MarketplaceComponent],
+      providers: [
+        provideRouter([]),
+        {
+          provide: AuthService,
+          useValue: {
+            getCurrentUser: vi.fn().mockReturnValue({ playerId: 1, coins: 1000 }),
+            refreshUser: vi.fn().mockResolvedValue(undefined),
+          },
+        },
+        {
+          provide: ListingService,
+          useValue: {
+            getActiveListings: vi.fn().mockReturnValue(of([])),
+            getListingsBySellerId: vi.fn().mockReturnValue(of([])),
+            cancelListing: vi.fn().mockReturnValue(of(undefined)),
+          },
+        },
+        {
+          provide: StoveService,
+          useValue: {
+            getAllStoveTypes: vi.fn().mockReturnValue(of([])),
+            getAllStoves: vi.fn().mockReturnValue(of([])),
+          },
+        },
+        {
+          provide: LootboxService,
+          useValue: {
+            getAllLootboxTypes: vi.fn().mockReturnValue(of([])),
+          },
+        },
+        {
+          provide: TradeService,
+          useValue: {
+            executeTrade: vi.fn().mockReturnValue(of(undefined)),
+          },
+        },
+        {
+          provide: PriceHistoryService,
+          useValue: {
+            getPriceHistoryByTypeId: vi.fn().mockReturnValue(of([])),
+          },
+        },
+      ],
     })
     .compileComponents();
 
-    fixture = TestBed.createComponent(Marketplace);
+    fixture = TestBed.createComponent(MarketplaceComponent);
     component = fixture.componentInstance;
     await fixture.whenStable();
   });

--- a/src/frontend/src/app/features/settings/pages/account/account.component.spec.ts
+++ b/src/frontend/src/app/features/settings/pages/account/account.component.spec.ts
@@ -1,14 +1,32 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { AuthService } from '@core/services/auth.service';
 
 import { AccountComponent } from './account.component';
 
 describe('AccountComponent', () => {
-  let component: Account;
-  let fixture: ComponentFixture<Account>;
+  let component: AccountComponent;
+  let fixture: ComponentFixture<AccountComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [AccountComponent]
+      imports: [AccountComponent],
+      providers: [
+        provideRouter([]),
+        {
+          provide: AuthService,
+          useValue: {
+            getCurrentUser: vi.fn().mockReturnValue({
+              playerId: 1,
+              username: 'Alice',
+              email: 'alice@example.com',
+              motto: '',
+              isPublic: true,
+            }),
+            updateProfile: vi.fn().mockResolvedValue(undefined),
+          },
+        },
+      ],
     })
     .compileComponents();
 

--- a/src/frontend/src/app/features/settings/pages/appearance/appearance.component.spec.ts
+++ b/src/frontend/src/app/features/settings/pages/appearance/appearance.component.spec.ts
@@ -3,10 +3,25 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { AppearanceComponent } from './appearance.component';
 
 describe('AppearanceComponent', () => {
-  let component: Appearance;
-  let fixture: ComponentFixture<Appearance>;
+  let component: AppearanceComponent;
+  let fixture: ComponentFixture<AppearanceComponent>;
 
   beforeEach(async () => {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: vi.fn(() => ({
+        matches: false,
+        media: '(prefers-color-scheme: dark)',
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      } as unknown as MediaQueryList)),
+    });
+
     await TestBed.configureTestingModule({
       imports: [AppearanceComponent]
     })

--- a/src/frontend/src/app/features/settings/pages/security/security.component.spec.ts
+++ b/src/frontend/src/app/features/settings/pages/security/security.component.spec.ts
@@ -1,14 +1,35 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { signal } from '@angular/core';
+import { AuthService } from '@core/services/auth.service';
 
 import { SecurityComponent } from './security.component';
 
 describe('SecurityComponent', () => {
-  let component: Security;
-  let fixture: ComponentFixture<Security>;
+  let component: SecurityComponent;
+  let fixture: ComponentFixture<SecurityComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [SecurityComponent]
+      imports: [SecurityComponent],
+      providers: [
+        provideRouter([]),
+        {
+          provide: AuthService,
+          useValue: {
+            isEmailVerified: signal(true),
+            getCurrentUser: vi.fn().mockReturnValue({ playerId: 1 }),
+            getSessionId: vi.fn().mockReturnValue('session-1'),
+            getSessions: vi.fn().mockResolvedValue([]),
+            get2FAStatus: vi.fn().mockResolvedValue({ enabled: false }),
+            logoutAllDevices: vi.fn().mockResolvedValue({ message: 'ok', closed: 1 }),
+            updatePassword: vi.fn().mockResolvedValue(undefined),
+            setup2FA: vi.fn().mockResolvedValue({ secret: 'secret', qrCodeDataUrl: 'data:image/png;base64,abc' }),
+            confirm2FA: vi.fn().mockResolvedValue({ message: 'ok' }),
+            disable2FA: vi.fn().mockResolvedValue({ message: 'ok' }),
+          },
+        },
+      ],
     })
     .compileComponents();
 

--- a/src/test/websocketTests/connection-manager.test.ts
+++ b/src/test/websocketTests/connection-manager.test.ts
@@ -1,0 +1,82 @@
+import WebSocket from "ws";
+import { connectionManager } from "../../backend/websocket/connection-manager";
+
+function mockSocket() {
+  return {
+    readyState: WebSocket.OPEN,
+    send: jest.fn(),
+    terminate: jest.fn(),
+  } as unknown as WebSocket & { send: jest.Mock; terminate: jest.Mock };
+}
+
+describe("WebSocket connection manager", () => {
+  afterEach(() => {
+    connectionManager.clearAll();
+  });
+
+  it("registers sockets and broadcasts to a room except excluded sockets", () => {
+    const socketA = mockSocket();
+    const socketB = mockSocket();
+    const socketC = mockSocket();
+
+    connectionManager.register("ws-a", socketA, 1);
+    connectionManager.register("ws-b", socketB, 2);
+    connectionManager.register("ws-c", socketC, 3);
+    connectionManager.joinRoom("ws-a", "room-1");
+    connectionManager.joinRoom("ws-b", "room-1");
+    connectionManager.joinRoom("ws-c", "room-2");
+
+    connectionManager.broadcastToRoom(
+      "room-1",
+      { type: "player_joined", payload: { playerId: 9 } },
+      "ws-a"
+    );
+
+    expect(socketA.send).not.toHaveBeenCalled();
+    expect(socketB.send).toHaveBeenCalledWith(
+      JSON.stringify({ type: "player_joined", payload: { playerId: 9 } })
+    );
+    expect(socketC.send).not.toHaveBeenCalled();
+  });
+
+  it("moves a socket when it joins a different room", () => {
+    const socket = mockSocket();
+    connectionManager.register("ws-a", socket, 1);
+
+    connectionManager.joinRoom("ws-a", "room-1");
+    connectionManager.joinRoom("ws-a", "room-2");
+
+    expect(connectionManager.getSocketIdsInRoom("room-1")).toEqual([]);
+    expect(connectionManager.getSocketIdsInRoom("room-2")).toEqual(["ws-a"]);
+    expect(connectionManager.getMeta("ws-a")?.roomId).toBe("room-2");
+  });
+
+  it("finds an open socket for a player in a room", () => {
+    const socket = mockSocket();
+    connectionManager.register("ws-a", socket, 42);
+    connectionManager.joinRoom("ws-a", "room-1");
+
+    expect(connectionManager.getSocketIdForPlayer("room-1", 42)).toBe("ws-a");
+    expect(connectionManager.getSocketIdForPlayer("room-1", 99)).toBeUndefined();
+  });
+
+  it("tracks duplicate sequence numbers per socket", () => {
+    const socket = mockSocket();
+    connectionManager.register("ws-a", socket, 1);
+
+    expect(connectionManager.isDuplicate("ws-a", 10)).toBe(false);
+    expect(connectionManager.isDuplicate("ws-a", 10)).toBe(true);
+    expect(connectionManager.isDuplicate("ws-a", 11)).toBe(false);
+  });
+
+  it("disconnect removes socket metadata and room membership", () => {
+    const socket = mockSocket();
+    connectionManager.register("ws-a", socket, 1);
+    connectionManager.joinRoom("ws-a", "room-1");
+
+    connectionManager.disconnect("ws-a");
+
+    expect(connectionManager.getMeta("ws-a")).toBeUndefined();
+    expect(connectionManager.getSocketIdsInRoom("room-1")).toEqual([]);
+  });
+});

--- a/src/test/websocketTests/message-handler.test.ts
+++ b/src/test/websocketTests/message-handler.test.ts
@@ -1,0 +1,163 @@
+import { ErrorCode } from "../../shared/model";
+
+const sendToSocket = jest.fn();
+const isDuplicate = jest.fn();
+const checkLimit = jest.fn();
+const handleJoinRoom = jest.fn();
+const handleLeaveRoom = jest.fn();
+const handlePlayerAction = jest.fn();
+const handleRequestSync = jest.fn();
+const handleStartGame = jest.fn();
+const handleChatMessage = jest.fn();
+
+jest.mock("../../backend/websocket/connection-manager", () => ({
+  connectionManager: {
+    sendToSocket,
+    isDuplicate,
+  },
+}));
+
+jest.mock("../../backend/websocket/rate-limiter", () => ({
+  rateLimiter: {
+    checkLimit,
+  },
+}));
+
+jest.mock("../../backend/websocket/handlers/join-room", () => ({
+  handleJoinRoom,
+}));
+
+jest.mock("../../backend/websocket/handlers/leave-room", () => ({
+  handleLeaveRoom,
+}));
+
+jest.mock("../../backend/websocket/handlers/player-action", () => ({
+  handlePlayerAction,
+}));
+
+jest.mock("../../backend/websocket/handlers/request-sync", () => ({
+  handleRequestSync,
+}));
+
+jest.mock("../../backend/websocket/handlers/start-game", () => ({
+  handleStartGame,
+}));
+
+jest.mock("../../backend/websocket/handlers/chat-message", () => ({
+  handleChatMessage,
+}));
+
+import { handleMessage } from "../../backend/websocket/message-handler";
+
+describe("WebSocket message handler", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    checkLimit.mockReturnValue(true);
+    isDuplicate.mockReturnValue(false);
+  });
+
+  it("rejects messages without a type", async () => {
+    await handleMessage("socket-1", "127.0.0.1", { sequenceNumber: 1 });
+
+    expect(sendToSocket).toHaveBeenCalledWith("socket-1", {
+      type: "error",
+      payload: {
+        code: ErrorCode.INVALID_STATE,
+        message: "Missing message type",
+        recoverable: true,
+      },
+    });
+  });
+
+  it("rejects messages without a sequence number", async () => {
+    await handleMessage("socket-1", "127.0.0.1", { type: "join_room" });
+
+    expect(sendToSocket).toHaveBeenCalledWith("socket-1", {
+      type: "error",
+      payload: {
+        code: ErrorCode.INVALID_STATE,
+        message: "Missing sequenceNumber",
+        recoverable: true,
+      },
+    });
+  });
+
+  it("rate limits by client IP before dispatching", async () => {
+    checkLimit.mockReturnValue(false);
+
+    await handleMessage("socket-1", "10.0.0.5", {
+      type: "join_room",
+      sequenceNumber: 1,
+      payload: { roomId: "room-1" },
+    });
+
+    expect(checkLimit).toHaveBeenCalledWith("10.0.0.5");
+    expect(handleJoinRoom).not.toHaveBeenCalled();
+    expect(sendToSocket).toHaveBeenCalledWith("socket-1", {
+      type: "error",
+      payload: {
+        code: ErrorCode.RATE_LIMITED,
+        message: "Too many messages",
+        recoverable: true,
+      },
+    });
+  });
+
+  it("drops duplicate sequence numbers without dispatching or sending an error", async () => {
+    isDuplicate.mockReturnValue(true);
+
+    await handleMessage("socket-1", "127.0.0.1", {
+      type: "player_action",
+      sequenceNumber: 7,
+      payload: { roomId: "room-1", actionType: "stand" },
+    });
+
+    expect(isDuplicate).toHaveBeenCalledWith("socket-1", 7);
+    expect(handlePlayerAction).not.toHaveBeenCalled();
+    expect(sendToSocket).not.toHaveBeenCalled();
+  });
+
+  it("supports snake_case sequence numbers and dispatches known message types", async () => {
+    const payload = { roomId: "room-1" };
+
+    await handleMessage("socket-1", "127.0.0.1", {
+      type: "join_room",
+      sequence_number: 12,
+      payload,
+    });
+
+    expect(isDuplicate).toHaveBeenCalledWith("socket-1", 12);
+    expect(handleJoinRoom).toHaveBeenCalledWith("socket-1", payload);
+  });
+
+  it("dispatches leave, action, sync, start, and chat messages", async () => {
+    await handleMessage("socket-1", "127.0.0.1", { type: "leave_room", sequenceNumber: 1, payload: { roomId: "r" } });
+    await handleMessage("socket-1", "127.0.0.1", { type: "player_action", sequenceNumber: 2, payload: { actionType: "hit" } });
+    await handleMessage("socket-1", "127.0.0.1", { type: "request_sync", sequenceNumber: 3, payload: { roomId: "r" } });
+    await handleMessage("socket-1", "127.0.0.1", { type: "start_game", sequenceNumber: 4, payload: { roomId: "r" } });
+    await handleMessage("socket-1", "127.0.0.1", { type: "chat_message", sequenceNumber: 5, payload: { content: "hello" } });
+
+    expect(handleLeaveRoom).toHaveBeenCalledTimes(1);
+    expect(handlePlayerAction).toHaveBeenCalledTimes(1);
+    expect(handleRequestSync).toHaveBeenCalledTimes(1);
+    expect(handleStartGame).toHaveBeenCalledTimes(1);
+    expect(handleChatMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns an error for unknown message types", async () => {
+    await handleMessage("socket-1", "127.0.0.1", {
+      type: "dance",
+      sequenceNumber: 1,
+      payload: {},
+    });
+
+    expect(sendToSocket).toHaveBeenCalledWith("socket-1", {
+      type: "error",
+      payload: {
+        code: ErrorCode.INVALID_STATE,
+        message: "Unknown message type: dance",
+        recoverable: true,
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds non-DB WebSocket tests for connection manager and message handler behavior
- Fixes existing Angular TestBed smoke specs
- Adds frontend service coverage for ThemeService and WebSocketService

## Tests
- Backend stable Jest suite: 67 suites, 707 tests passed
- Frontend Angular tests: 7 files, 13 tests passed