### PR TITLE
feat(blackjack): staged card animations and dealer draw tension

### DIFF
--- a/docs/superpowers/plans/2026-06-17-blackjack-animation.md
+++ b/docs/superpowers/plans/2026-06-17-blackjack-animation.md
@@ -1,0 +1,1219 @@
+# Blackjack Game-Flow Animation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a frontend-only staged animation layer to Blackjack so cards deal one-by-one, the dealer draws with visible pauses, and results reveal with satisfying highlights — without changing the backend.
+
+**Architecture:** A new `BlackjackStageManager` class receives the authoritative WebSocket state, compares it to the currently displayed state, and replays card differences through a timed event queue. The existing `BlackjackComponent` renders from the manager’s `displayedStateBlob` and disables controls while `isAnimating()` is true.
+
+**Tech Stack:** Angular 21 signals, TypeScript, Jest with `jest.useFakeTimers()`, Tailwind CSS v4, component styles in `blackjack.css`.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `src/frontend/src/app/features/blackjack/blackjack-stage-manager.ts` | Owns target/displayed state, diffing, event queue, timing config, reduced-motion detection, and entering-card IDs. |
+| `src/test/blackjack-stage-manager.test.ts` | Unit tests for deal sequence, dealer draw, reduced motion, and jump detection. |
+| `src/frontend/src/app/features/blackjack/blackjack.ts` | Wires the stage manager, exposes `isAnimating`/`stage`, disables actions during animations, delays results overlay. |
+| `src/frontend/src/app/features/blackjack/blackjack.html` | Renders from displayed state, shows stage messages while animating, binds entering-card class. |
+| `src/frontend/src/app/features/blackjack/blackjack.css` | Moves deal-in animation to `.card-flip--entering`, adds hand highlight classes and chip-payout keyframes. |
+
+---
+
+## Task 1: Create `BlackjackStageManager` skeleton + snap test
+
+**Files:**
+- Create: `src/frontend/src/app/features/blackjack/blackjack-stage-manager.ts`
+- Test: `src/test/blackjack-stage-manager.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/test/blackjack-stage-manager.test.ts
+import { BlackjackStageManager } from '../src/frontend/src/app/features/blackjack/blackjack-stage-manager';
+
+function makeBlob(
+  phase: string,
+  dealerHand: string[],
+  players: Record<string, unknown>[]
+): Record<string, unknown> {
+  return {
+    status: 'active',
+    phase,
+    dealerHand,
+    players,
+    activePlayer: -1,
+    activeHandIndex: 0,
+    currentBet: 20,
+    validActions: [],
+  };
+}
+
+describe('BlackjackStageManager', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  it('snaps to a betting state instantly', () => {
+    const mgr = new BlackjackStageManager();
+    mgr.setTarget(makeBlob('betting', [], []));
+
+    expect(mgr.displayedStateBlob()?.['phase']).toBe('betting');
+    expect(mgr.isAnimating()).toBe(false);
+    expect(mgr.stage()).toBe('idle');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run: `npm test -- src/test/blackjack-stage-manager.test.ts`
+
+Expected: FAIL — `Cannot find module` or class not found.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+```ts
+// src/frontend/src/app/features/blackjack/blackjack-stage-manager.ts
+import { signal } from '@angular/core';
+
+export type BlackjackStage =
+  | 'idle'
+  | 'dealing'
+  | 'player-turn'
+  | 'dealer-turn'
+  | 'settling';
+
+export interface StageManagerOptions {
+  reducedMotion?: boolean;
+}
+
+export class BlackjackStageManager {
+  readonly targetStateBlob = signal<Record<string, unknown> | null>(null);
+  readonly displayedStateBlob = signal<Record<string, unknown> | null>(null);
+  readonly isAnimating = signal(false);
+  readonly stage = signal<BlackjackStage>('idle');
+  readonly enteringCardIds = signal<Set<string>>(new Set());
+
+  private readonly reducedMotion: boolean;
+
+  constructor(options: StageManagerOptions = {}) {
+    this.reducedMotion = options.reducedMotion ?? false;
+  }
+
+  setTarget(blob: Record<string, unknown> | null): void {
+    this.targetStateBlob.set(blob);
+    if (this.reducedMotion || !blob) {
+      this.jumpTo(blob);
+      return;
+    }
+    // Full animation logic added in later tasks.
+    this.jumpTo(blob);
+  }
+
+  private jumpTo(blob: Record<string, unknown> | null): void {
+    this.displayedStateBlob.set(blob ? clone(blob) : null);
+    this.isAnimating.set(false);
+    this.stage.set('idle');
+    this.enteringCardIds.set(new Set());
+  }
+}
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value));
+}
+```
+
+- [ ] **Step 4: Run the test and verify it passes**
+
+Run: `npm test -- src/test/blackjack-stage-manager.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/frontend/src/app/features/blackjack/blackjack-stage-manager.ts src/test/blackjack-stage-manager.test.ts
+git commit -m "feat(blackjack): add BlackjackStageManager skeleton with snap behavior"
+```
+
+---
+
+## Task 2: Implement initial-deal animation
+
+**Files:**
+- Modify: `src/frontend/src/app/features/blackjack/blackjack-stage-manager.ts`
+- Modify: `src/test/blackjack-stage-manager.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add this test to `src/test/blackjack-stage-manager.test.ts`:
+
+```ts
+import { buildPlayerCardId, buildDealerCardId, TIMING } from '../src/frontend/src/app/features/blackjack/blackjack-stage-manager';
+
+it('stages an initial deal one card at a time', () => {
+  const mgr = new BlackjackStageManager();
+  mgr.setTarget(makeBlob('betting', [], []));
+  jest.advanceTimersByTime(0);
+
+  const target = makeBlob('player_turn', ['5h', 'back'], [
+    {
+      playerId: 1,
+      username: 'Hero',
+      stack: 1000,
+      hands: [['Ah', '10d']],
+      bets: [20],
+      result: 'playing',
+    },
+  ]);
+
+  mgr.setTarget(target);
+
+  // Reset event applies immediately (delay 0)
+  expect(mgr.isAnimating()).toBe(true);
+  expect(mgr.stage()).toBe('dealing');
+  expect((mgr.displayedStateBlob()?.['players'] as any[])[0].hands[0]).toEqual([]);
+
+  // First player card
+  jest.advanceTimersByTime(350);
+  expect((mgr.displayedStateBlob()?.['players'] as any[])[0].hands[0]).toEqual(['Ah']);
+  expect(mgr.enteringCardIds().has(buildPlayerCardId(1, 0, 0, 'Ah'))).toBe(true);
+
+  // Dealer upcard
+  jest.advanceTimersByTime(350);
+  expect(mgr.displayedStateBlob()?.['dealerHand']).toEqual(['5h']);
+
+  // Second player card
+  jest.advanceTimersByTime(350);
+  expect((mgr.displayedStateBlob()?.['players'] as any[])[0].hands[0]).toEqual(['Ah', '10d']);
+
+  // Dealer hole
+  jest.advanceTimersByTime(350);
+  expect(mgr.displayedStateBlob()?.['dealerHand']).toEqual(['5h', 'back']);
+
+  // Queue finishes
+  jest.advanceTimersByTime(350);
+  expect(mgr.isAnimating()).toBe(false);
+  expect(mgr.stage()).toBe('idle');
+});
+```
+
+Run: `npm test -- src/test/blackjack-stage-manager.test.ts`
+
+Expected: FAIL — only the reset event happens, no card events.
+
+- [ ] **Step 2: Implement event generation and queue**
+
+Replace the body of `BlackjackStageManager` with the full deal logic. Keep the existing public API.
+
+```ts
+export const TIMING = {
+  dealStagger: 350,
+  holeFlip: 500,
+  dealerDrawPause: 700,
+  settlePause: 400,
+  enteringCardDuration: 500,
+};
+
+type AnimationEvent =
+  | { type: 'reset_deal'; stage: BlackjackStage; delay: number }
+  | { type: 'deal_player_card'; stage: BlackjackStage; delay: number; playerId: number; handIndex: number; index: number; card: string }
+  | { type: 'deal_dealer_upcard'; stage: BlackjackStage; delay: number; card: string }
+  | { type: 'deal_dealer_hole'; stage: BlackjackStage; delay: number }
+  | { type: 'reveal_hole_card'; stage: BlackjackStage; delay: number; card: string }
+  | { type: 'dealer_draw'; stage: BlackjackStage; delay: number; index: number; card: string }
+  | { type: 'player_draw'; stage: BlackjackStage; delay: number; playerId: number; handIndex: number; index: number; card: string }
+  | { type: 'settle'; stage: BlackjackStage; delay: number };
+
+export function buildPlayerCardId(
+  playerId: number,
+  handIndex: number,
+  index: number,
+  card: string
+): string {
+  return `${playerId}-${handIndex}-${index}-${card}`;
+}
+
+export function buildDealerCardId(index: number, card: string): string {
+  return `dealer-${index}-${card}`;
+}
+
+export class BlackjackStageManager {
+  readonly targetStateBlob = signal<Record<string, unknown> | null>(null);
+  readonly displayedStateBlob = signal<Record<string, unknown> | null>(null);
+  readonly isAnimating = signal(false);
+  readonly stage = signal<BlackjackStage>('idle');
+  readonly enteringCardIds = signal<Set<string>>(new Set());
+
+  private readonly reducedMotion: boolean;
+  private queueRunning = false;
+  private pendingTarget: Record<string, unknown> | null = null;
+
+  constructor(options: StageManagerOptions = {}) {
+    this.reducedMotion = options.reducedMotion ?? false;
+  }
+
+  setTarget(blob: Record<string, unknown> | null): void {
+    this.targetStateBlob.set(blob);
+    if (this.queueRunning) {
+      this.pendingTarget = blob;
+      return;
+    }
+    if (this.reducedMotion || !blob || this.shouldJump(blob)) {
+      this.jumpTo(blob);
+      return;
+    }
+    const events = this.buildEvents(blob);
+    if (events.length === 0) {
+      this.displayedStateBlob.set(clone(blob));
+      this.stage.set('idle');
+      return;
+    }
+    this.runEvents(events);
+  }
+
+  private shouldJump(blob: Record<string, unknown>): boolean {
+    const displayedPhase = normalizePhase(
+      String(this.displayedStateBlob()?.['phase'] ?? '')
+    );
+    const targetPhase = normalizePhase(String(blob['phase'] ?? ''));
+    if (targetPhase === 'betting') return true;
+    if (!displayedPhase || displayedPhase === targetPhase) return false;
+
+    // Normal flow can skip insurance (betting -> playing), so allow that single step.
+    if (displayedPhase === 'betting' && targetPhase === 'playing') return false;
+
+    const order = ['betting', 'insurance', 'playing', 'dealer', 'showdown'];
+    const dIdx = order.indexOf(displayedPhase);
+    const tIdx = order.indexOf(targetPhase);
+    if (dIdx < 0 || tIdx < 0) return true;
+    return tIdx < dIdx || tIdx - dIdx > 1;
+  }
+
+  private jumpTo(blob: Record<string, unknown> | null): void {
+    this.displayedStateBlob.set(blob ? clone(blob) : null);
+    this.isAnimating.set(false);
+    this.stage.set('idle');
+    this.enteringCardIds.set(new Set());
+    this.queueRunning = false;
+    this.pendingTarget = null;
+  }
+
+  private buildEvents(blob: Record<string, unknown>): AnimationEvent[] {
+    const targetPhase = normalizePhase(String(blob['phase'] ?? ''));
+    const displayedPhase = normalizePhase(
+      String(this.displayedStateBlob()?.['phase'] ?? '')
+    );
+    const events: AnimationEvent[] = [];
+
+    if (targetPhase === 'playing' && displayedPhase !== 'playing') {
+      events.push({ type: 'reset_deal', stage: 'dealing', delay: 0 });
+
+      const players = (blob['players'] as any[]) ?? [];
+      const hands = players.flatMap((p) =>
+        ((p['hands'] as string[][]) ?? []).map((hand, handIndex) => ({
+          playerId: p['playerId'] as number,
+          handIndex,
+          cards: hand,
+        }))
+      );
+
+      // First card to every hand
+      for (const hand of hands) {
+        events.push({
+          type: 'deal_player_card',
+          stage: 'dealing',
+          delay: TIMING.dealStagger,
+          playerId: hand.playerId,
+          handIndex: hand.handIndex,
+          index: 0,
+          card: hand.cards[0],
+        });
+      }
+
+      const dealerHand = (blob['dealerHand'] as string[]) ?? [];
+      if (dealerHand.length > 0) {
+        events.push({
+          type: 'deal_dealer_upcard',
+          stage: 'dealing',
+          delay: TIMING.dealStagger,
+          card: dealerHand[0],
+        });
+      }
+
+      // Second card to every hand
+      for (const hand of hands) {
+        if (hand.cards.length > 1) {
+          events.push({
+            type: 'deal_player_card',
+            stage: 'dealing',
+            delay: TIMING.dealStagger,
+            playerId: hand.playerId,
+            handIndex: hand.handIndex,
+            index: 1,
+            card: hand.cards[1],
+          });
+        }
+      }
+
+      if (dealerHand.length > 1) {
+        events.push({
+          type: 'deal_dealer_hole',
+          stage: 'dealing',
+          delay: TIMING.dealStagger,
+        });
+      }
+    }
+
+    return events;
+  }
+
+  private runEvents(events: AnimationEvent[]): void {
+    this.queueRunning = true;
+    this.isAnimating.set(true);
+    let i = 0;
+
+    const step = () => {
+      if (i >= events.length) {
+        this.queueRunning = false;
+        this.isAnimating.set(false);
+        this.stage.set('idle');
+        if (this.pendingTarget !== null) {
+          const next = this.pendingTarget;
+          this.pendingTarget = null;
+          this.setTarget(next);
+        }
+        return;
+      }
+
+      const event = events[i++];
+      this.stage.set(event.stage);
+      setTimeout(() => {
+        this.applyEvent(event);
+        step();
+      }, event.delay);
+    };
+
+    step();
+  }
+
+  private applyEvent(event: AnimationEvent): void {
+    const target = this.targetStateBlob();
+    const next = clone(this.displayedStateBlob() ?? {});
+
+    switch (event.type) {
+      case 'reset_deal': {
+        if (target) {
+          this.displayedStateBlob.set(this.blankStateFrom(target));
+        }
+        return;
+      }
+      case 'deal_player_card': {
+        const player = ((next['players'] as any[]) ?? []).find(
+          (p) => p['playerId'] === event.playerId
+        );
+        if (player) {
+          player['hands'][event.handIndex].push(event.card);
+          this.markEntering(
+            buildPlayerCardId(
+              event.playerId,
+              event.handIndex,
+              event.index,
+              event.card
+            )
+          );
+        }
+        break;
+      }
+      case 'deal_dealer_upcard': {
+        (next['dealerHand'] as string[]).push(event.card);
+        this.markEntering(buildDealerCardId(0, event.card));
+        break;
+      }
+      case 'deal_dealer_hole': {
+        (next['dealerHand'] as string[]).push('back');
+        break;
+      }
+      default:
+        break;
+    }
+
+    this.displayedStateBlob.set(next);
+  }
+
+  private markEntering(id: string): void {
+    const ids = new Set(this.enteringCardIds());
+    ids.add(id);
+    this.enteringCardIds.set(ids);
+    setTimeout(() => {
+      const updated = new Set(this.enteringCardIds());
+      updated.delete(id);
+      this.enteringCardIds.set(updated);
+    }, TIMING.enteringCardDuration);
+  }
+
+  private blankStateFrom(target: Record<string, unknown>): Record<string, unknown> {
+    const copy = clone(target);
+    copy['dealerHand'] = [];
+    const players = (copy['players'] as any[]) ?? [];
+    for (const player of players) {
+      const hands = (player['hands'] as string[][]) ?? [];
+      player['hands'] = hands.map(() => []);
+    }
+    return copy;
+  }
+}
+
+function normalizePhase(raw: string): string {
+  if (raw === 'player_turn') return 'playing';
+  if (raw === 'dealer_turn') return 'dealer';
+  if (raw === 'settled') return 'showdown';
+  return raw;
+}
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value));
+}
+```
+
+- [ ] **Step 3: Run the test and verify it passes**
+
+Run: `npm test -- src/test/blackjack-stage-manager.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/frontend/src/app/features/blackjack/blackjack-stage-manager.ts src/test/blackjack-stage-manager.test.ts
+git commit -m "feat(blackjack): stage initial deal one card at a time"
+```
+
+---
+
+## Task 3: Implement dealer-turn animation
+
+**Files:**
+- Modify: `src/frontend/src/app/features/blackjack/blackjack-stage-manager.ts`
+- Modify: `src/test/blackjack-stage-manager.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add this test:
+
+```ts
+it('reveals the hole card and draws dealer cards one by one', () => {
+  const mgr = new BlackjackStageManager();
+
+  // Start from a fully dealt playing state
+  mgr.setTarget(
+    makeBlob('player_turn', ['5h', 'back'], [
+      {
+        playerId: 1,
+        username: 'Hero',
+        stack: 1000,
+        hands: [['Ah', '10d']],
+        bets: [20],
+        result: 'playing',
+      },
+    ])
+  );
+  jest.advanceTimersByTime(10_000); // finish initial deal
+
+  mgr.setTarget(
+    makeBlob('dealer_turn', ['5h', '8c', 'Ks'], [
+      {
+        playerId: 1,
+        username: 'Hero',
+        stack: 1000,
+        hands: [['Ah', '10d']],
+        bets: [20],
+        result: 'playing',
+      },
+    ])
+  );
+
+  expect(mgr.isAnimating()).toBe(true);
+  expect(mgr.stage()).toBe('dealer-turn');
+
+  // Hole card revealed
+  jest.advanceTimersByTime(TIMING.holeFlip);
+  expect(mgr.displayedStateBlob()?.['dealerHand']).toEqual(['5h', '8c']);
+
+  // First dealer draw
+  jest.advanceTimersByTime(TIMING.dealerDrawPause);
+  expect(mgr.displayedStateBlob()?.['dealerHand']).toEqual(['5h', '8c', 'Ks']);
+
+  // Queue finishes
+  jest.advanceTimersByTime(TIMING.dealerDrawPause);
+  expect(mgr.isAnimating()).toBe(false);
+  expect(mgr.stage()).toBe('idle');
+});
+```
+
+Run: `npm test -- src/test/blackjack-stage-manager.test.ts`
+
+Expected: FAIL — dealer cards appear instantly because dealer events are not generated.
+
+- [ ] **Step 2: Extend `buildEvents` and `applyEvent` for dealer turn**
+
+In `buildEvents`, after the initial-deal block, add:
+
+```ts
+const dealerTarget = (blob['dealerHand'] as string[]) ?? [];
+const dealerDisplayed = ((this.displayedStateBlob()?.['dealerHand'] as string[]) ?? []);
+
+if (targetPhase === 'dealer' || targetPhase === 'showdown') {
+  if (dealerDisplayed[1] === 'back' && dealerTarget[1] && dealerTarget[1] !== 'back') {
+    events.push({
+      type: 'reveal_hole_card',
+      stage: 'dealer-turn',
+      delay: events.length === 0 ? 0 : TIMING.holeFlip,
+      card: dealerTarget[1],
+    });
+  }
+
+  for (let i = 2; i < dealerTarget.length; i++) {
+    if (i >= dealerDisplayed.length || dealerDisplayed[i] !== dealerTarget[i]) {
+      events.push({
+        type: 'dealer_draw',
+        stage: 'dealer-turn',
+        delay: TIMING.dealerDrawPause,
+        index: i,
+        card: dealerTarget[i],
+      });
+    }
+  }
+}
+```
+
+In `applyEvent`, add cases:
+
+```ts
+case 'reveal_hole_card': {
+  const hand = next['dealerHand'] as string[];
+  hand[1] = event.card;
+  this.markEntering(buildDealerCardId(1, event.card));
+  break;
+}
+case 'dealer_draw': {
+  (next['dealerHand'] as string[]).push(event.card);
+  this.markEntering(buildDealerCardId(event.index, event.card));
+  break;
+}
+```
+
+- [ ] **Step 3: Run the test and verify it passes**
+
+Run: `npm test -- src/test/blackjack-stage-manager.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/frontend/src/app/features/blackjack/blackjack-stage-manager.ts src/test/blackjack-stage-manager.test.ts
+git commit -m "feat(blackjack): stage dealer hole reveal and draws"
+```
+
+---
+
+## Task 4: Implement player-hit and settle animations
+
+**Files:**
+- Modify: `src/frontend/src/app/features/blackjack/blackjack-stage-manager.ts`
+- Modify: `src/test/blackjack-stage-manager.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add these tests:
+
+```ts
+it('animates a player hit', () => {
+  const mgr = new BlackjackStageManager();
+  mgr.setTarget(
+    makeBlob('player_turn', ['5h', 'back'], [
+      {
+        playerId: 1,
+        username: 'Hero',
+        stack: 1000,
+        hands: [['Ah', '10d']],
+        bets: [20],
+        result: 'playing',
+      },
+    ])
+  );
+  jest.advanceTimersByTime(10_000);
+
+  mgr.setTarget(
+    makeBlob('player_turn', ['5h', 'back'], [
+      {
+        playerId: 1,
+        username: 'Hero',
+        stack: 1000,
+        hands: [['Ah', '10d', '3c']],
+        bets: [20],
+        result: 'playing',
+      },
+    ])
+  );
+
+  expect(mgr.isAnimating()).toBe(true);
+  expect(mgr.stage()).toBe('player-turn');
+
+  jest.advanceTimersByTime(TIMING.dealStagger);
+  expect((mgr.displayedStateBlob()?.['players'] as any[])[0].hands[0]).toEqual([
+    'Ah',
+    '10d',
+    '3c',
+  ]);
+
+  jest.advanceTimersByTime(TIMING.dealStagger);
+  expect(mgr.isAnimating()).toBe(false);
+});
+
+it('animates the settle highlight', () => {
+  const mgr = new BlackjackStageManager();
+  mgr.setTarget(
+    makeBlob('dealer_turn', ['5h', '8c', 'Ks'], [
+      {
+        playerId: 1,
+        username: 'Hero',
+        stack: 1000,
+        hands: [['Ah', '10d']],
+        bets: [20],
+        result: 'won',
+        handResults: ['won'],
+      },
+    ])
+  );
+  jest.advanceTimersByTime(10_000);
+
+  mgr.setTarget(
+    makeBlob('settled', ['5h', '8c', 'Ks'], [
+      {
+        playerId: 1,
+        username: 'Hero',
+        stack: 1020,
+        hands: [['Ah', '10d']],
+        bets: [20],
+        result: 'won',
+        handResults: ['won'],
+      },
+    ])
+  );
+
+  expect(mgr.isAnimating()).toBe(true);
+  expect(mgr.stage()).toBe('settling');
+
+  jest.advanceTimersByTime(TIMING.settlePause);
+  expect((mgr.displayedStateBlob()?.['players'] as any[])[0].result).toBe('won');
+  expect(mgr.isAnimating()).toBe(false);
+});
+```
+
+Run: `npm test -- src/test/blackjack-stage-manager.test.ts`
+
+Expected: FAIL — player hits and settle are not handled.
+
+- [ ] **Step 2: Extend `buildEvents` and `applyEvent`**
+
+In `buildEvents`, after the dealer block, add:
+
+```ts
+if (targetPhase === 'playing' && displayedPhase === 'playing') {
+  const targetPlayers = (blob['players'] as any[]) ?? [];
+  const displayedPlayers = ((this.displayedStateBlob()?.['players'] as any[]) ?? []);
+
+  for (const tp of targetPlayers) {
+    const playerId = tp['playerId'] as number;
+    const dp = displayedPlayers.find((p) => p['playerId'] === playerId);
+    const targetHands = (tp['hands'] as string[][]) ?? [];
+    const displayedHands = ((dp?.['hands'] as string[][]) ?? []).map((h) => h ?? []);
+
+    for (let h = 0; h < targetHands.length; h++) {
+      const displayedHand = displayedHands[h] ?? [];
+      for (let i = displayedHand.length; i < targetHands[h].length; i++) {
+        events.push({
+          type: 'player_draw',
+          stage: 'player-turn',
+          delay: TIMING.dealStagger,
+          playerId,
+          handIndex: h,
+          index: i,
+          card: targetHands[h][i],
+        });
+      }
+    }
+  }
+}
+
+if (targetPhase === 'showdown') {
+  events.push({ type: 'settle', stage: 'settling', delay: TIMING.settlePause });
+}
+```
+
+In `applyEvent`, add:
+
+```ts
+case 'player_draw': {
+  const player = ((next['players'] as any[]) ?? []).find(
+    (p) => p['playerId'] === event.playerId
+  );
+  if (player) {
+    player['hands'][event.handIndex].push(event.card);
+    this.markEntering(
+      buildPlayerCardId(event.playerId, event.handIndex, event.index, event.card)
+    );
+  }
+  break;
+}
+case 'settle': {
+  const target = this.targetStateBlob();
+  if (target) {
+    this.displayedStateBlob.set(clone(target));
+  }
+  return;
+}
+```
+
+- [ ] **Step 3: Run the tests and verify they pass**
+
+Run: `npm test -- src/test/blackjack-stage-manager.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/frontend/src/app/features/blackjack/blackjack-stage-manager.ts src/test/blackjack-stage-manager.test.ts
+git commit -m "feat(blackjack): stage player draws and settle reveal"
+```
+
+---
+
+## Task 5: Add reduced-motion and jump-detection tests
+
+**Files:**
+- Modify: `src/test/blackjack-stage-manager.test.ts`
+
+- [ ] **Step 1: Write the tests**
+
+```ts
+it('snaps instantly when reduced motion is preferred', () => {
+  const mgr = new BlackjackStageManager({ reducedMotion: true });
+  mgr.setTarget(
+    makeBlob('player_turn', ['5h', 'back'], [
+      {
+        playerId: 1,
+        username: 'Hero',
+        stack: 1000,
+        hands: [['Ah', '10d']],
+        bets: [20],
+        result: 'playing',
+      },
+    ])
+  );
+
+  expect(mgr.isAnimating()).toBe(false);
+  expect((mgr.displayedStateBlob()?.['players'] as any[])[0].hands[0]).toEqual([
+    'Ah',
+    '10d',
+  ]);
+});
+
+it('jumps ahead on reconnect or phase skip', () => {
+  const mgr = new BlackjackStageManager();
+  mgr.setTarget(makeBlob('betting', [], []));
+  jest.advanceTimersByTime(0);
+
+  // Dealer phase would normally animate, but we leap from betting → dealer
+  mgr.setTarget(
+    makeBlob('dealer_turn', ['5h', '8c', 'Ks'], [
+      {
+        playerId: 1,
+        username: 'Hero',
+        stack: 1000,
+        hands: [['Ah', '10d']],
+        bets: [20],
+        result: 'playing',
+      },
+    ])
+  );
+
+  expect(mgr.isAnimating()).toBe(false);
+  expect(mgr.displayedStateBlob()?.['dealerHand']).toEqual(['5h', '8c', 'Ks']);
+});
+```
+
+- [ ] **Step 2: Run the tests and verify they pass**
+
+Run: `npm test -- src/test/blackjack-stage-manager.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/test/blackjack-stage-manager.test.ts
+git commit -m "test(blackjack): reduced motion and jump detection"
+```
+
+---
+
+## Task 6: Move card enter animation to a modifier class
+
+**Files:**
+- Modify: `src/frontend/src/app/features/blackjack/blackjack.css`
+
+- [ ] **Step 1: Update CSS**
+
+```css
+/* Remove the always-on animation from .card-flip */
+.card-flip {
+  perspective: 800px;
+  flex-shrink: 0;
+}
+
+/* Only newly entering cards animate */
+.card-flip--entering {
+  animation: card-deal-in 0.45s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+```
+
+The existing `@keyframes card-deal-in` stays as-is.
+
+- [ ] **Step 2: Verify no visual regressions**
+
+Run: `npm run frontend:build`
+
+Expected: Build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/frontend/src/app/features/blackjack/blackjack.css
+git commit -m "style(blackjack): only animate newly entering cards"
+```
+
+---
+
+## Task 7: Add hand highlight and chip payout styles
+
+**Files:**
+- Modify: `src/frontend/src/app/features/blackjack/blackjack.css`
+
+- [ ] **Step 1: Add hand highlight classes**
+
+```css
+.bj-hand--win {
+  outline: 2px solid rgba(74, 222, 128, 0.6);
+  outline-offset: 2px;
+  border-radius: 12px;
+}
+
+.bj-hand--lose {
+  outline: 2px solid rgba(239, 83, 80, 0.5);
+  outline-offset: 2px;
+  border-radius: 12px;
+}
+
+.bj-hand--push {
+  outline: 2px solid var(--border);
+  outline-offset: 2px;
+  border-radius: 12px;
+}
+```
+
+- [ ] **Step 2: Add chip payout animation**
+
+```css
+.bj-hand--win .bj-chip,
+.bj-hand--blackjack .bj-chip {
+  animation: chip-payout 0.65s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+
+@keyframes chip-payout {
+  0% {
+    transform: translateX(-50%) translateY(0) scale(1);
+    opacity: 1;
+  }
+  60% {
+    transform: translateX(-50%) translateY(-28px) scale(1.1);
+    opacity: 1;
+  }
+  100% {
+    transform: translateX(-50%) translateY(-40px) scale(0.85);
+    opacity: 0;
+  }
+}
+```
+
+- [ ] **Step 3: Build and commit**
+
+Run: `npm run frontend:build`
+
+Expected: Build succeeds.
+
+```bash
+git add src/frontend/src/app/features/blackjack/blackjack.css
+git commit -m "style(blackjack): hand highlights and chip payout animation"
+```
+
+---
+
+## Task 8: Wire `BlackjackStageManager` into the component
+
+**Files:**
+- Modify: `src/frontend/src/app/features/blackjack/blackjack.ts`
+- Modify: `src/frontend/src/app/features/blackjack/blackjack.html`
+
+- [ ] **Step 1: Update `blackjack.ts`**
+
+Inject the stage manager at the top of the component class:
+
+```ts
+import { BlackjackStageManager } from './blackjack-stage-manager';
+
+export class BlackjackComponent {
+  private ws = inject(WebSocketService);
+  private auth = inject(AuthService);
+  private stageManager = new BlackjackStageManager({
+    reducedMotion: window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+  });
+
+  readonly stateBlob = this.stageManager.displayedStateBlob;
+  readonly lastError = this.ws.lastError;
+
+  readonly isAnimating = this.stageManager.isAnimating;
+  readonly stage = this.stageManager.stage;
+  readonly enteringCardIds = this.stageManager.enteringCardIds;
+
+  // ... existing computed signals stay as-is because they read stateBlob ...
+```
+
+Feed the WebSocket target into the manager in the constructor:
+
+```ts
+constructor() {
+  // Feed authoritative state into the stage manager
+  effect(() => {
+    this.stageManager.setTarget(this.ws.stateBlob());
+  });
+
+  // existing constructor body stays below
+}
+```
+
+Disable actions while animating:
+
+```ts
+  canAction(type: string): boolean {
+    return !this.isAnimating() && this.validActions().some((a) => a.type === type);
+  }
+```
+
+Add a stage message computed:
+
+```ts
+  readonly stageMessage = computed(() => {
+    switch (this.stage()) {
+      case 'dealing': return 'Dealing…';
+      case 'dealer-turn': return 'Dealer is drawing…';
+      case 'settling': return 'Settling…';
+      default: return '';
+    }
+  });
+```
+
+Update the results-overlay effect in the constructor to wait for animations to finish:
+
+```ts
+  effect(() => {
+    const currentPhase = this.phase();
+    const animating = this.isAnimating();
+
+    if (currentPhase !== lastPhase) {
+      lastPhase = currentPhase;
+      // phase announcements stay here (unchanged)
+      if (currentPhase === 'insurance') { ... }
+      else if (currentPhase === 'dealer') { ... }
+      else if (currentPhase === 'showdown') { ... }
+      else { this.showAnnouncement.set(false); }
+
+      if (currentPhase === 'betting') {
+        this.betAmount.set(this.minBet());
+      }
+    }
+
+    // Results overlay: only trigger once dealer/settle animation is done
+    if (currentPhase === 'showdown' && !animating) {
+      if (!showdownTimer) {
+        showdownTimer = window.setTimeout(() => {
+          this.showResultsOverlay.set(true);
+        }, 2000);
+      }
+    } else {
+      if (showdownTimer) {
+        clearTimeout(showdownTimer);
+        showdownTimer = null;
+      }
+      this.showResultsOverlay.set(false);
+    }
+  });
+```
+
+- [ ] **Step 2: Update `blackjack.html`**
+
+Wrap the control bar with an animation message first:
+
+```html
+<div class="bj-control-bar absolute bottom-[4%] left-1/2 -translate-x-1/2 z-20">
+  @if (isAnimating()) {
+    <div class="bj-control-bar__panel bj-control-bar__panel--message px-6 py-3">
+      <span class="bj-controls__message text-base font-semibold text-white/80 italic">{{ stageMessage() }}</span>
+    </div>
+  } @else {
+    <!-- existing control-bar branches stay here unchanged -->
+  }
+</div>
+```
+
+Bind the entering-card class on every `.card-flip`:
+
+For dealer cards:
+```html
+<div
+  class="card-flip card-flip--dealer"
+  [class.face-down]="!card.faceUp"
+  [class.face-up]="card.faceUp"
+  [class.card-flip--entering]="enteringCardIds().has(card.cardId)"
+>
+```
+
+For player cards:
+```html
+<div
+  class="card-flip card-flip--player"
+  [class.face-down]="!card.faceUp"
+  [class.face-up]="card.faceUp"
+  [class.card-flip--entering]="enteringCardIds().has(card.cardId)"
+>
+```
+
+Add `cardId` to the `BlackjackCard` interface and populate it in the two `cards.map` calls:
+
+```ts
+export interface BlackjackCard {
+  rank: string;
+  suit: string;
+  faceUp: boolean;
+  cardId: string;
+}
+```
+
+In `dealerHand` computed:
+
+```ts
+return cards.map((c, index) => ({
+  rank: this.cardRank(c),
+  suit: this.cardSuit(c),
+  faceUp: c !== 'back',
+  cardId: buildDealerCardId(index, c),
+}));
+```
+
+In the player hands computed:
+
+```ts
+const cards: BlackjackCard[] = handCards.map((c, index) => ({
+  rank: this.cardRank(c),
+  suit: this.cardSuit(c),
+  faceUp: c !== 'back',
+  cardId: buildPlayerCardId(playerId, idx, index, c),
+}));
+```
+
+Add hand-status highlight classes to `.bj-hand`:
+
+```html
+<div
+  class="bj-hand flex flex-col items-center gap-1"
+  [class.bj-hand--active]="hand.isCurrentTurn"
+  [class.bj-hand--settled]="isShowdown()"
+  [class.bj-hand--win]="hand.status === 'win' || hand.status === 'blackjack'"
+  [class.bj-hand--lose]="hand.status === 'lose' || hand.status === 'bust'"
+  [class.bj-hand--push]="hand.status === 'push'"
+>
+```
+
+- [ ] **Step 3: Build and test**
+
+Run: `npm run frontend:build`
+
+Expected: Build succeeds.
+
+Run: `npm test -- src/test/blackjack-stage-manager.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/frontend/src/app/features/blackjack/blackjack.ts src/frontend/src/app/features/blackjack/blackjack.html
+git commit -m "feat(blackjack): wire stage manager into component and template"
+```
+
+---
+
+## Task 9: Manual visual verification
+
+**Files:** none (manual)
+
+- [ ] **Step 1: Start the dev server**
+
+Run: `npm run dev:full`
+
+Wait for the backend and Angular dev server to start.
+
+- [ ] **Step 2: Play a few hands**
+
+Open `http://localhost:4200`, join a Blackjack table, and verify:
+
+1. After all bets, the control bar shows **“Dealing…”** and cards appear one-by-one.
+2. Your own cards are visible above the control bar.
+3. When it is your turn, controls appear only after dealing finishes.
+4. When you hit, the new card animates in.
+5. During the dealer turn, the hole card flips and each draw is visible.
+6. Winning/losing hands get a colored highlight; chips hop on wins.
+7. The results overlay appears after the settle animation.
+8. With **prefers-reduced-motion** enabled in the OS/browser, everything snaps instantly.
+
+- [ ] **Step 3: Commit any final tweaks**
+
+```bash
+git add -A
+git commit -m "polish(blackjack): final timing tweaks from manual testing"
+```
+
+---
+
+## Spec Coverage Check
+
+| Spec Requirement | Task(s) |
+|---|---|
+| Frontend-only, no backend changes | All tasks |
+| Staggered initial deal | Task 2 |
+| Hole-card flip | Task 3 |
+| Dealer draws one-by-one | Task 3 |
+| Result/payout highlight | Task 4, Task 7 |
+| `prefers-reduced-motion` | Task 1 options, Task 5, Task 8 |
+| Reconnect/jump detection | Task 1 `shouldJump`, Task 5 |
+| Disable controls during animation | Task 8 |
+| Delay results overlay until animation ends | Task 8 |
+
+## Placeholder Scan
+
+No placeholders. Every step includes exact file paths, code blocks, commands, and expected outcomes.

--- a/docs/superpowers/specs/2026-06-17-blackjack-animation-design.md
+++ b/docs/superpowers/specs/2026-06-17-blackjack-animation-design.md
@@ -1,0 +1,156 @@
+# Blackjack Game-Flow Animation Design
+
+**Date:** 2026-06-17  
+**Scope:** Frontend-only polish for the Blackjack game page. No backend or WebSocket protocol changes.
+
+## Summary
+
+The Blackjack server still resolves each round in one atomic update and sends the final `state_update` to every client. This design introduces a frontend **stage manager** that receives that authoritative state and replays the card changes with deliberate timing, creating moments of tension: a staggered initial deal, a flipped hole card, the dealer drawing one card at a time, and a highlighted result reveal.
+
+Players who reconnect, refresh, or inspect the network payload still see the final truth immediately. The animation is purely a visual presentation layer.
+
+## Goals
+
+- Make the initial deal feel like cards are actually being handed out.
+- Make the dealer turn suspenseful by revealing/drawing cards one at a time instead of spawning the full hand.
+- Add a short, satisfying result/payout highlight before the results overlay appears.
+- Keep the implementation isolated to the frontend Blackjack feature.
+- Respect `prefers-reduced-motion` by snapping to the final state instantly.
+
+## Non-Goals
+
+- No changes to `src/backend/game-engines/blackjack-engine.ts` or WebSocket message types.
+- No sound effects (the design leaves hooks for them, but they are out of scope).
+- No artificial network delays or throttling.
+- No animated card movement across the table (e.g., from a deck sprite to a seat); we use an in-place entrance/flip animation.
+
+## Architecture
+
+```
+WebSocketService.stateBlob (authoritative)
+           │
+           ▼
+BlackjackStageManager
+  - targetStateBlob    (what the server says RIGHT NOW)
+  - displayedStateBlob (what the UI is currently showing)
+  - isAnimating        (true while staged reveal is running)
+  - stage              (idle | dealing | player-turn | dealer-turn | settling)
+           │
+           ▼
+BlackjackComponent
+  - renders from displayedStateBlob
+  - disables actions while isAnimating is true
+  - triggers announcement/overlay based on displayed state and stage
+```
+
+`BlackjackStageManager` is a plain injectable class (not a global service) created and owned by the Blackjack component. It owns no WebSocket knowledge beyond receiving the raw state blob.
+
+## Data Flow
+
+1. On every `state_update`, the component writes the new blob into `stageManager.setTarget(blob)`.
+2. `StageManager` compares the new target to the currently displayed state and emits a list of animation events.
+3. Events are processed through a small async queue with fixed delays. Each event mutates `displayedStateBlob` incrementally.
+4. The component reads `displayedStateBlob` for all rendering: dealer hand, player hands, active states, result rows, etc.
+5. While the queue is running, `isAnimating` is `true`. The component uses this to disable controls and show a message such as “Dealing…” or “Dealer is drawing…”.
+
+## Animation Events
+
+| Event | Trigger | Visual Effect |
+|---|---|---|
+| `deal_player_card` | A player hand gains a card that did not exist in the previous displayed state. | New card element enters with `card-deal-in` animation. |
+| `deal_dealer_upcard` | Dealer hand length goes from 0 → 1. | First dealer card enters. |
+| `deal_dealer_hole` | Dealer hand length goes from 1 → 2 and the second card is `back`. | Second dealer card enters face-down. |
+| `reveal_hole_card` | Target phase becomes `dealer_turn` (or dealer hand index 1 changes from `back` to real). | The face-down hole card flips to face-up. |
+| `dealer_draw` | Dealer hand length grows beyond 2 while target phase is `dealer_turn`. | New dealer card enters. |
+| `player_draw` | A player hand length grows during `player_turn`. | New card enters for that hand. |
+| `settle` | Target phase becomes `settled` / `showdown` and dealer hand is fully revealed. | Winning/losing hands highlight; chip stack animates; results overlay delayed until this event. |
+| `jump` | The target state is more than one meaningful step ahead of the displayed state (reconnect, late join, split timing mismatch). | Snap displayed state to target instantly with no animation. |
+
+## Timing Constants
+
+All delays are centralized in one config object so they can be tuned in one place.
+
+```ts
+const ANIMATION_TIMING = {
+  dealStagger: 350,      // ms between each initial-deal card
+  holeFlip: 500,         // ms for the hole-card flip
+  dealerDrawPause: 700,  // ms between dealer draws
+  settlePause: 400,      // ms after dealer finishes before result reveal
+};
+```
+
+If `prefers-reduced-motion` is active, all delays become `0` and `jump` is used for every transition.
+
+## Card Identity & Diffing
+
+The raw state stores cards as strings like `"Ah"` or `"back"`. To detect additions reliably, the stage manager builds stable IDs:
+
+- Player cards: `${playerId}-${handIndex}-${index}-${cardString}`
+- Dealer cards: `dealer-${index}-${cardString}`
+
+Because the hole card changes from `"back"` to a real card, its ID changes. The manager treats that transition as a `reveal_hole_card` event rather than a remove+add.
+
+## State Mapping
+
+- `displayedStateBlob.phase` equals `targetStateBlob.phase`. This keeps the existing control logic (`isBetting`, `isPlaying`, etc.) working without rewrites.
+- `displayedStateBlob.dealerHand` and `displayedStateBlob.players[].hands` are staged subsets of the target arrays.
+- All other fields (`winners`, `validActions`, `activePlayer`, chip stacks) are copied from the target immediately.
+
+Controls are disabled during animation via `stageManager.isAnimating()`, not by lagging the phase.
+
+## Component Changes
+
+### New files
+
+- `src/frontend/src/app/features/blackjack/blackjack-stage-manager.ts`
+  - Owns target/displayed signals, diffing, queue, and timing config.
+  - Exposes `setTarget(blob)`, `displayedStateBlob`, `isAnimating`, `stage`.
+
+### Modified files
+
+- `src/frontend/src/app/features/blackjack/blackjack.ts`
+  - Inject `BlackjackStageManager`.
+  - Replace `stateBlob` reads with `stageManager.displayedStateBlob` for derived card state.
+  - Pass `stageManager.isAnimating()` into `canAction`/button disabled states.
+  - Use `stageManager.stage()` to drive the “Dealing…” / “Dealer is drawing…” messages.
+  - Delay the results overlay until `phase === 'showdown' && !isAnimating()`.
+
+- `src/frontend/src/app/features/blackjack/blackjack.html`
+  - Render from displayed state.
+  - Show animated stage messages while `isAnimating()`.
+  - Keep the conditional front-face image for face-down cards.
+
+- `src/frontend/src/app/features/blackjack/blackjack.css`
+  - Add `.card-flip--entering` modifier for the deal-in animation.
+  - Add hand highlight classes: `.bj-hand--win`, `.bj-hand--lose`, `.bj-hand--push`.
+  - Add chip-payout animation keyframes.
+
+## Edge Cases & Error Handling
+
+- **Reconnect / late join:** If the target phase jumped ahead by more than one stage, `stageManager` snaps to the target immediately.
+- **User action during animation:** Buttons are disabled while `isAnimating()` is true. Any in-flight `player_action` response that arrives mid-animation is queued as the next target.
+- **Split:** A new hand is treated like a new player; its cards are dealt with the same stagger.
+- **Double:** The single extra card is animated as a `player_draw` event.
+- **Blackjack on deal:** If a hand is already blackjack after two cards, the result highlight still waits until the settle stage so it does not distract from the deal animation.
+- **Reduced motion:** The queue runs with zero delay; `displayedStateBlob` becomes `targetStateBlob` on the next tick.
+
+## Accessibility
+
+- Honor `prefers-reduced-motion: reduce`.
+- Keep `aria-live` announcements for phase changes; do not announce every card individually to avoid screen-reader chatter.
+- Disable controls during animation with `aria-disabled` and a visible reason (the stage message).
+
+## Testing
+
+- Unit-test `BlackjackStageManager` with synthetic state blobs:
+  - deal sequence,
+  - dealer draw sequence,
+  - hole-card reveal,
+  - jump detection,
+  - reduced-motion snap.
+- Visually verify on a real Blackjack table that dealer cards appear one by one and the results overlay waits for the animation.
+
+## Open Questions / Tuning
+
+- Exact timing constants may need adjustment after play-testing; they are in one config object.
+- Whether the initial deal should be “one card per player, repeat” or “each player gets both cards, then dealer” is left to implementation, with the ability to change the event ordering in the stage manager.

--- a/src/frontend/src/app/features/blackjack/blackjack-stage-manager.ts
+++ b/src/frontend/src/app/features/blackjack/blackjack-stage-manager.ts
@@ -173,26 +173,59 @@ export class BlackjackStageManager {
     const dealerDisplayed = ((this.displayedStateBlob()?.['dealerHand'] as string[]) ?? []);
 
     if (targetPhase === 'dealer' || targetPhase === 'showdown') {
-      if (dealerDisplayed[1] === 'back' && dealerTarget[1] && dealerTarget[1] !== 'back') {
-        events.push({
-          type: 'reveal_hole_card',
-          stage: 'dealer-turn',
-          delay: events.length === 0 ? 0 : TIMING.holeFlip,
-          card: dealerTarget[1],
-        });
-      }
-
-      for (let i = 2; i < dealerTarget.length; i++) {
-        if (i >= dealerDisplayed.length || dealerDisplayed[i] !== dealerTarget[i]) {
+      if (dealerDisplayed.length >= 2) {
+        if (dealerDisplayed[1] === 'back' && dealerTarget[1] && dealerTarget[1] !== 'back') {
           events.push({
-            type: 'dealer_draw',
+            type: 'reveal_hole_card',
             stage: 'dealer-turn',
-            delay: TIMING.dealerDrawPause,
-            index: i,
-            card: dealerTarget[i],
+            delay: events.length === 0 ? 0 : TIMING.holeFlip,
+            card: dealerTarget[1],
           });
         }
+
+        for (let i = 2; i < dealerTarget.length; i++) {
+          if (i >= dealerDisplayed.length || dealerDisplayed[i] !== dealerTarget[i]) {
+            events.push({
+              type: 'dealer_draw',
+              stage: 'dealer-turn',
+              delay: TIMING.dealerDrawPause,
+              index: i,
+              card: dealerTarget[i],
+            });
+          }
+        }
       }
+    }
+
+    if (targetPhase === 'playing' && displayedPhase === 'playing') {
+      const targetPlayers = (blob['players'] as any[]) ?? [];
+      const displayedPlayers = ((this.displayedStateBlob()?.['players'] as any[]) ?? []);
+
+      for (const tp of targetPlayers) {
+        const playerId = tp['playerId'] as number;
+        const dp = displayedPlayers.find((p) => p['playerId'] === playerId);
+        const targetHands = (tp['hands'] as string[][]) ?? [];
+        const displayedHands = ((dp?.['hands'] as string[][]) ?? []).map((h) => h ?? []);
+
+        for (let h = 0; h < targetHands.length; h++) {
+          const displayedHand = displayedHands[h] ?? [];
+          for (let i = displayedHand.length; i < targetHands[h].length; i++) {
+            events.push({
+              type: 'player_draw',
+              stage: 'player-turn',
+              delay: TIMING.dealStagger,
+              playerId,
+              handIndex: h,
+              index: i,
+              card: targetHands[h][i],
+            });
+          }
+        }
+      }
+    }
+
+    if (targetPhase === 'showdown') {
+      events.push({ type: 'settle', stage: 'settling', delay: TIMING.settlePause });
     }
 
     return events;
@@ -276,9 +309,30 @@ export class BlackjackStageManager {
         break;
       }
       case 'dealer_draw': {
-        (next['dealerHand'] as string[]).push(event.card);
+        const dealerHand = (next['dealerHand'] as string[]) ?? [];
+        dealerHand.push(event.card);
+        next['dealerHand'] = dealerHand;
         this.markEntering(buildDealerCardId(event.index, event.card));
         break;
+      }
+      case 'player_draw': {
+        const player = ((next['players'] as any[]) ?? []).find(
+          (p) => p['playerId'] === event.playerId
+        );
+        if (player) {
+          player['hands'][event.handIndex].push(event.card);
+          this.markEntering(
+            buildPlayerCardId(event.playerId, event.handIndex, event.index, event.card)
+          );
+        }
+        break;
+      }
+      case 'settle': {
+        const target = this.targetStateBlob();
+        if (target) {
+          this.displayedStateBlob.set(clone(target));
+        }
+        return;
       }
       default:
         break;

--- a/src/frontend/src/app/features/blackjack/blackjack-stage-manager.ts
+++ b/src/frontend/src/app/features/blackjack/blackjack-stage-manager.ts
@@ -1,0 +1,47 @@
+import { signal } from '@angular/core';
+
+export type BlackjackStage =
+  | 'idle'
+  | 'dealing'
+  | 'player-turn'
+  | 'dealer-turn'
+  | 'settling';
+
+export interface StageManagerOptions {
+  reducedMotion?: boolean;
+}
+
+export class BlackjackStageManager {
+  readonly targetStateBlob = signal<Record<string, unknown> | null>(null);
+  readonly displayedStateBlob = signal<Record<string, unknown> | null>(null);
+  readonly isAnimating = signal(false);
+  readonly stage = signal<BlackjackStage>('idle');
+  readonly enteringCardIds = signal<Set<string>>(new Set());
+
+  private readonly reducedMotion: boolean;
+
+  constructor(options: StageManagerOptions = {}) {
+    this.reducedMotion = options.reducedMotion ?? false;
+  }
+
+  setTarget(blob: Record<string, unknown> | null): void {
+    this.targetStateBlob.set(blob);
+    if (this.reducedMotion || !blob) {
+      this.jumpTo(blob);
+      return;
+    }
+    // Full animation logic added in later tasks.
+    this.jumpTo(blob);
+  }
+
+  private jumpTo(blob: Record<string, unknown> | null): void {
+    this.displayedStateBlob.set(blob ? clone(blob) : null);
+    this.isAnimating.set(false);
+    this.stage.set('idle');
+    this.enteringCardIds.set(new Set());
+  }
+}
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value));
+}

--- a/src/frontend/src/app/features/blackjack/blackjack-stage-manager.ts
+++ b/src/frontend/src/app/features/blackjack/blackjack-stage-manager.ts
@@ -52,6 +52,7 @@ export class BlackjackStageManager {
   private readonly reducedMotion: boolean;
   private queueRunning = false;
   private pendingTarget: Record<string, unknown> | null = null;
+  private readonly timers: Array<ReturnType<typeof setTimeout>> = [];
 
   constructor(options: StageManagerOptions = {}) {
     this.reducedMotion = options.reducedMotion ?? false;
@@ -231,7 +232,7 @@ export class BlackjackStageManager {
       }
     }
 
-    if (targetPhase === 'showdown') {
+    if (targetPhase === 'showdown' && displayedPhase !== 'showdown') {
       events.push({ type: 'settle', stage: 'settling', delay: TIMING.settlePause });
     }
 
@@ -262,7 +263,7 @@ export class BlackjackStageManager {
         this.applyEvent(event);
         step();
       } else {
-        setTimeout(() => {
+        this.schedule(() => {
           this.applyEvent(event);
           step();
         }, event.delay);
@@ -352,11 +353,42 @@ export class BlackjackStageManager {
     const ids = new Set(this.enteringCardIds());
     ids.add(id);
     this.enteringCardIds.set(ids);
-    setTimeout(() => {
+    this.schedule(() => {
       const updated = new Set(this.enteringCardIds());
       updated.delete(id);
       this.enteringCardIds.set(updated);
     }, TIMING.enteringCardDuration);
+  }
+
+  private schedule(
+    callback: () => void,
+    delay: number
+  ): ReturnType<typeof setTimeout> {
+    const id = setTimeout(() => {
+      this.clearTimer(id);
+      callback();
+    }, delay);
+    this.timers.push(id);
+    return id;
+  }
+
+  private clearTimer(id: ReturnType<typeof setTimeout>): void {
+    const index = this.timers.indexOf(id);
+    if (index >= 0) {
+      this.timers.splice(index, 1);
+    }
+  }
+
+  destroy(): void {
+    for (const id of this.timers) {
+      clearTimeout(id);
+    }
+    this.timers.length = 0;
+    this.pendingTarget = null;
+    this.queueRunning = false;
+    this.isAnimating.set(false);
+    this.stage.set('idle');
+    this.enteringCardIds.set(new Set());
   }
 
   private blankStateFrom(target: Record<string, unknown>): Record<string, unknown> {

--- a/src/frontend/src/app/features/blackjack/blackjack-stage-manager.ts
+++ b/src/frontend/src/app/features/blackjack/blackjack-stage-manager.ts
@@ -82,6 +82,15 @@ export class BlackjackStageManager {
     );
     const targetPhase = normalizePhase(String(blob['phase'] ?? ''));
     if (targetPhase === 'betting') return true;
+
+    const displayedDealerHand = ((this.displayedStateBlob()?.['dealerHand'] as string[]) ?? []);
+    if (
+      (targetPhase === 'dealer' || targetPhase === 'showdown') &&
+      displayedDealerHand.length < 2
+    ) {
+      return true;
+    }
+
     if (!displayedPhase || displayedPhase === targetPhase) return false;
 
     // Normal flow can skip insurance (betting -> playing), so allow that single step.
@@ -173,26 +182,24 @@ export class BlackjackStageManager {
     const dealerDisplayed = ((this.displayedStateBlob()?.['dealerHand'] as string[]) ?? []);
 
     if (targetPhase === 'dealer' || targetPhase === 'showdown') {
-      if (dealerDisplayed.length >= 2) {
-        if (dealerDisplayed[1] === 'back' && dealerTarget[1] && dealerTarget[1] !== 'back') {
-          events.push({
-            type: 'reveal_hole_card',
-            stage: 'dealer-turn',
-            delay: events.length === 0 ? 0 : TIMING.holeFlip,
-            card: dealerTarget[1],
-          });
-        }
+      if (dealerDisplayed[1] === 'back' && dealerTarget[1] && dealerTarget[1] !== 'back') {
+        events.push({
+          type: 'reveal_hole_card',
+          stage: 'dealer-turn',
+          delay: events.length === 0 ? 0 : TIMING.holeFlip,
+          card: dealerTarget[1],
+        });
+      }
 
-        for (let i = 2; i < dealerTarget.length; i++) {
-          if (i >= dealerDisplayed.length || dealerDisplayed[i] !== dealerTarget[i]) {
-            events.push({
-              type: 'dealer_draw',
-              stage: 'dealer-turn',
-              delay: TIMING.dealerDrawPause,
-              index: i,
-              card: dealerTarget[i],
-            });
-          }
+      for (let i = 2; i < dealerTarget.length; i++) {
+        if (i >= dealerDisplayed.length || dealerDisplayed[i] !== dealerTarget[i]) {
+          events.push({
+            type: 'dealer_draw',
+            stage: 'dealer-turn',
+            delay: TIMING.dealerDrawPause,
+            index: i,
+            card: dealerTarget[i],
+          });
         }
       }
     }

--- a/src/frontend/src/app/features/blackjack/blackjack-stage-manager.ts
+++ b/src/frontend/src/app/features/blackjack/blackjack-stage-manager.ts
@@ -169,6 +169,32 @@ export class BlackjackStageManager {
       }
     }
 
+    const dealerTarget = (blob['dealerHand'] as string[]) ?? [];
+    const dealerDisplayed = ((this.displayedStateBlob()?.['dealerHand'] as string[]) ?? []);
+
+    if (targetPhase === 'dealer' || targetPhase === 'showdown') {
+      if (dealerDisplayed[1] === 'back' && dealerTarget[1] && dealerTarget[1] !== 'back') {
+        events.push({
+          type: 'reveal_hole_card',
+          stage: 'dealer-turn',
+          delay: events.length === 0 ? 0 : TIMING.holeFlip,
+          card: dealerTarget[1],
+        });
+      }
+
+      for (let i = 2; i < dealerTarget.length; i++) {
+        if (i >= dealerDisplayed.length || dealerDisplayed[i] !== dealerTarget[i]) {
+          events.push({
+            type: 'dealer_draw',
+            stage: 'dealer-turn',
+            delay: TIMING.dealerDrawPause,
+            index: i,
+            card: dealerTarget[i],
+          });
+        }
+      }
+    }
+
     return events;
   }
 
@@ -241,6 +267,17 @@ export class BlackjackStageManager {
       }
       case 'deal_dealer_hole': {
         (next['dealerHand'] as string[]).push('back');
+        break;
+      }
+      case 'reveal_hole_card': {
+        const hand = next['dealerHand'] as string[];
+        hand[1] = event.card;
+        this.markEntering(buildDealerCardId(1, event.card));
+        break;
+      }
+      case 'dealer_draw': {
+        (next['dealerHand'] as string[]).push(event.card);
+        this.markEntering(buildDealerCardId(event.index, event.card));
         break;
       }
       default:

--- a/src/frontend/src/app/features/blackjack/blackjack-stage-manager.ts
+++ b/src/frontend/src/app/features/blackjack/blackjack-stage-manager.ts
@@ -11,6 +11,37 @@ export interface StageManagerOptions {
   reducedMotion?: boolean;
 }
 
+export const TIMING = {
+  dealStagger: 350,
+  holeFlip: 500,
+  dealerDrawPause: 700,
+  settlePause: 400,
+  enteringCardDuration: 500,
+};
+
+type AnimationEvent =
+  | { type: 'reset_deal'; stage: BlackjackStage; delay: number }
+  | { type: 'deal_player_card'; stage: BlackjackStage; delay: number; playerId: number; handIndex: number; index: number; card: string }
+  | { type: 'deal_dealer_upcard'; stage: BlackjackStage; delay: number; card: string }
+  | { type: 'deal_dealer_hole'; stage: BlackjackStage; delay: number }
+  | { type: 'reveal_hole_card'; stage: BlackjackStage; delay: number; card: string }
+  | { type: 'dealer_draw'; stage: BlackjackStage; delay: number; index: number; card: string }
+  | { type: 'player_draw'; stage: BlackjackStage; delay: number; playerId: number; handIndex: number; index: number; card: string }
+  | { type: 'settle'; stage: BlackjackStage; delay: number };
+
+export function buildPlayerCardId(
+  playerId: number,
+  handIndex: number,
+  index: number,
+  card: string
+): string {
+  return `${playerId}-${handIndex}-${index}-${card}`;
+}
+
+export function buildDealerCardId(index: number, card: string): string {
+  return `dealer-${index}-${card}`;
+}
+
 export class BlackjackStageManager {
   readonly targetStateBlob = signal<Record<string, unknown> | null>(null);
   readonly displayedStateBlob = signal<Record<string, unknown> | null>(null);
@@ -19,6 +50,8 @@ export class BlackjackStageManager {
   readonly enteringCardIds = signal<Set<string>>(new Set());
 
   private readonly reducedMotion: boolean;
+  private queueRunning = false;
+  private pendingTarget: Record<string, unknown> | null = null;
 
   constructor(options: StageManagerOptions = {}) {
     this.reducedMotion = options.reducedMotion ?? false;
@@ -26,12 +59,39 @@ export class BlackjackStageManager {
 
   setTarget(blob: Record<string, unknown> | null): void {
     this.targetStateBlob.set(blob);
-    if (this.reducedMotion || !blob) {
+    if (this.queueRunning) {
+      this.pendingTarget = blob;
+      return;
+    }
+    if (this.reducedMotion || !blob || this.shouldJump(blob)) {
       this.jumpTo(blob);
       return;
     }
-    // Full animation logic added in later tasks.
-    this.jumpTo(blob);
+    const events = this.buildEvents(blob);
+    if (events.length === 0) {
+      this.displayedStateBlob.set(clone(blob));
+      this.stage.set('idle');
+      return;
+    }
+    this.runEvents(events);
+  }
+
+  private shouldJump(blob: Record<string, unknown>): boolean {
+    const displayedPhase = normalizePhase(
+      String(this.displayedStateBlob()?.['phase'] ?? '')
+    );
+    const targetPhase = normalizePhase(String(blob['phase'] ?? ''));
+    if (targetPhase === 'betting') return true;
+    if (!displayedPhase || displayedPhase === targetPhase) return false;
+
+    // Normal flow can skip insurance (betting -> playing), so allow that single step.
+    if (displayedPhase === 'betting' && targetPhase === 'playing') return false;
+
+    const order = ['betting', 'insurance', 'playing', 'dealer', 'showdown'];
+    const dIdx = order.indexOf(displayedPhase);
+    const tIdx = order.indexOf(targetPhase);
+    if (dIdx < 0 || tIdx < 0) return true;
+    return tIdx < dIdx || tIdx - dIdx > 1;
   }
 
   private jumpTo(blob: Record<string, unknown> | null): void {
@@ -39,7 +99,185 @@ export class BlackjackStageManager {
     this.isAnimating.set(false);
     this.stage.set('idle');
     this.enteringCardIds.set(new Set());
+    this.queueRunning = false;
+    this.pendingTarget = null;
   }
+
+  private buildEvents(blob: Record<string, unknown>): AnimationEvent[] {
+    const targetPhase = normalizePhase(String(blob['phase'] ?? ''));
+    const displayedPhase = normalizePhase(
+      String(this.displayedStateBlob()?.['phase'] ?? '')
+    );
+    const events: AnimationEvent[] = [];
+
+    if (targetPhase === 'playing' && displayedPhase !== 'playing') {
+      events.push({ type: 'reset_deal', stage: 'dealing', delay: 0 });
+
+      const players = (blob['players'] as any[]) ?? [];
+      const hands = players.flatMap((p) =>
+        ((p['hands'] as string[][]) ?? []).map((hand, handIndex) => ({
+          playerId: p['playerId'] as number,
+          handIndex,
+          cards: hand,
+        }))
+      );
+
+      // First card to every hand
+      for (const hand of hands) {
+        events.push({
+          type: 'deal_player_card',
+          stage: 'dealing',
+          delay: TIMING.dealStagger,
+          playerId: hand.playerId,
+          handIndex: hand.handIndex,
+          index: 0,
+          card: hand.cards[0],
+        });
+      }
+
+      const dealerHand = (blob['dealerHand'] as string[]) ?? [];
+      if (dealerHand.length > 0) {
+        events.push({
+          type: 'deal_dealer_upcard',
+          stage: 'dealing',
+          delay: TIMING.dealStagger,
+          card: dealerHand[0],
+        });
+      }
+
+      // Second card to every hand
+      for (const hand of hands) {
+        if (hand.cards.length > 1) {
+          events.push({
+            type: 'deal_player_card',
+            stage: 'dealing',
+            delay: TIMING.dealStagger,
+            playerId: hand.playerId,
+            handIndex: hand.handIndex,
+            index: 1,
+            card: hand.cards[1],
+          });
+        }
+      }
+
+      if (dealerHand.length > 1) {
+        events.push({
+          type: 'deal_dealer_hole',
+          stage: 'dealing',
+          delay: TIMING.dealStagger,
+        });
+      }
+    }
+
+    return events;
+  }
+
+  private runEvents(events: AnimationEvent[]): void {
+    this.queueRunning = true;
+    this.isAnimating.set(true);
+    let i = 0;
+
+    const step = () => {
+      if (i >= events.length) {
+        this.queueRunning = false;
+        this.isAnimating.set(false);
+        this.stage.set('idle');
+        if (this.pendingTarget !== null) {
+          const next = this.pendingTarget;
+          this.pendingTarget = null;
+          this.setTarget(next);
+        }
+        return;
+      }
+
+      const event = events[i++];
+      this.stage.set(event.stage);
+      if (event.delay === 0) {
+        this.applyEvent(event);
+        step();
+      } else {
+        setTimeout(() => {
+          this.applyEvent(event);
+          step();
+        }, event.delay);
+      }
+    };
+
+    step();
+  }
+
+  private applyEvent(event: AnimationEvent): void {
+    const target = this.targetStateBlob();
+    const next = clone(this.displayedStateBlob() ?? {});
+
+    switch (event.type) {
+      case 'reset_deal': {
+        if (target) {
+          this.displayedStateBlob.set(this.blankStateFrom(target));
+        }
+        return;
+      }
+      case 'deal_player_card': {
+        const player = ((next['players'] as any[]) ?? []).find(
+          (p) => p['playerId'] === event.playerId
+        );
+        if (player) {
+          player['hands'][event.handIndex].push(event.card);
+          this.markEntering(
+            buildPlayerCardId(
+              event.playerId,
+              event.handIndex,
+              event.index,
+              event.card
+            )
+          );
+        }
+        break;
+      }
+      case 'deal_dealer_upcard': {
+        (next['dealerHand'] as string[]).push(event.card);
+        this.markEntering(buildDealerCardId(0, event.card));
+        break;
+      }
+      case 'deal_dealer_hole': {
+        (next['dealerHand'] as string[]).push('back');
+        break;
+      }
+      default:
+        break;
+    }
+
+    this.displayedStateBlob.set(next);
+  }
+
+  private markEntering(id: string): void {
+    const ids = new Set(this.enteringCardIds());
+    ids.add(id);
+    this.enteringCardIds.set(ids);
+    setTimeout(() => {
+      const updated = new Set(this.enteringCardIds());
+      updated.delete(id);
+      this.enteringCardIds.set(updated);
+    }, TIMING.enteringCardDuration);
+  }
+
+  private blankStateFrom(target: Record<string, unknown>): Record<string, unknown> {
+    const copy = clone(target);
+    copy['dealerHand'] = [];
+    const players = (copy['players'] as any[]) ?? [];
+    for (const player of players) {
+      const hands = (player['hands'] as string[][]) ?? [];
+      player['hands'] = hands.map(() => []);
+    }
+    return copy;
+  }
+}
+
+function normalizePhase(raw: string): string {
+  if (raw === 'player_turn') return 'playing';
+  if (raw === 'dealer_turn') return 'dealer';
+  if (raw === 'settled') return 'showdown';
+  return raw;
 }
 
 function clone<T>(value: T): T {

--- a/src/frontend/src/app/features/blackjack/blackjack-stage-manager.ts
+++ b/src/frontend/src/app/features/blackjack/blackjack-stage-manager.ts
@@ -16,7 +16,7 @@ export const TIMING = {
   holeFlip: 500,
   dealerDrawPause: 700,
   settlePause: 400,
-  enteringCardDuration: 500,
+  enteringCardDuration: 450,
 };
 
 type AnimationEvent =
@@ -32,14 +32,13 @@ type AnimationEvent =
 export function buildPlayerCardId(
   playerId: number,
   handIndex: number,
-  index: number,
-  card: string
+  index: number
 ): string {
-  return `${playerId}-${handIndex}-${index}-${card}`;
+  return `${playerId}-${handIndex}-${index}`;
 }
 
-export function buildDealerCardId(index: number, card: string): string {
-  return `dealer-${index}-${card}`;
+export function buildDealerCardId(index: number): string {
+  return `dealer-${index}`;
 }
 
 export class BlackjackStageManager {
@@ -92,7 +91,14 @@ export class BlackjackStageManager {
       return true;
     }
 
-    if (!displayedPhase || displayedPhase === targetPhase) return false;
+    if (!displayedPhase) return false;
+
+    if (displayedPhase === targetPhase) {
+      if (targetPhase === 'playing' && this.hasStructuralHandChange(blob)) {
+        return true;
+      }
+      return false;
+    }
 
     // Normal flow can skip insurance (betting -> playing), so allow that single step.
     if (displayedPhase === 'betting' && targetPhase === 'playing') return false;
@@ -102,6 +108,26 @@ export class BlackjackStageManager {
     const tIdx = order.indexOf(targetPhase);
     if (dIdx < 0 || tIdx < 0) return true;
     return tIdx < dIdx || tIdx - dIdx > 1;
+  }
+
+  private hasStructuralHandChange(target: Record<string, unknown>): boolean {
+    const targetPlayers = (target['players'] as any[]) ?? [];
+    const displayedPlayers = ((this.displayedStateBlob()?.['players'] as any[]) ?? []);
+
+    for (const tp of targetPlayers) {
+      const playerId = tp['playerId'] as number;
+      const dp = displayedPlayers.find((p) => p['playerId'] === playerId);
+      const targetHands = (tp['hands'] as string[][]) ?? [];
+      const displayedHands = ((dp?.['hands'] as string[][]) ?? []);
+
+      if (targetHands.length !== displayedHands.length) return true;
+
+      for (let h = 0; h < targetHands.length; h++) {
+        const displayedHand = displayedHands[h] ?? [];
+        if (targetHands[h].length < displayedHand.length) return true;
+      }
+    }
+    return false;
   }
 
   private jumpTo(blob: Record<string, unknown> | null): void {
@@ -294,8 +320,7 @@ export class BlackjackStageManager {
             buildPlayerCardId(
               event.playerId,
               event.handIndex,
-              event.index,
-              event.card
+              event.index
             )
           );
         }
@@ -303,7 +328,7 @@ export class BlackjackStageManager {
       }
       case 'deal_dealer_upcard': {
         (next['dealerHand'] as string[]).push(event.card);
-        this.markEntering(buildDealerCardId(0, event.card));
+        this.markEntering(buildDealerCardId(0));
         break;
       }
       case 'deal_dealer_hole': {
@@ -313,14 +338,14 @@ export class BlackjackStageManager {
       case 'reveal_hole_card': {
         const hand = next['dealerHand'] as string[];
         hand[1] = event.card;
-        this.markEntering(buildDealerCardId(1, event.card));
+        this.markEntering(buildDealerCardId(1));
         break;
       }
       case 'dealer_draw': {
         const dealerHand = (next['dealerHand'] as string[]) ?? [];
         dealerHand.push(event.card);
         next['dealerHand'] = dealerHand;
-        this.markEntering(buildDealerCardId(event.index, event.card));
+        this.markEntering(buildDealerCardId(event.index));
         break;
       }
       case 'player_draw': {
@@ -330,7 +355,7 @@ export class BlackjackStageManager {
         if (player) {
           player['hands'][event.handIndex].push(event.card);
           this.markEntering(
-            buildPlayerCardId(event.playerId, event.handIndex, event.index, event.card)
+            buildPlayerCardId(event.playerId, event.handIndex, event.index)
           );
         }
         break;

--- a/src/frontend/src/app/features/blackjack/blackjack-stage-manager.ts
+++ b/src/frontend/src/app/features/blackjack/blackjack-stage-manager.ts
@@ -52,24 +52,38 @@ export class BlackjackStageManager {
   private queueRunning = false;
   private pendingTarget: Record<string, unknown> | null = null;
   private readonly timers: Array<ReturnType<typeof setTimeout>> = [];
+  private lastProcessedJson = '';
 
   constructor(options: StageManagerOptions = {}) {
     this.reducedMotion = options.reducedMotion ?? false;
   }
 
   setTarget(blob: Record<string, unknown> | null): void {
-    this.targetStateBlob.set(blob);
     if (this.queueRunning) {
-      this.pendingTarget = blob;
+      // Queue the latest non-duplicate target to be processed after animation.
+      if (JSON.stringify(blob) !== this.lastProcessedJson) {
+        this.pendingTarget = blob;
+      }
       return;
     }
+
+    const json = JSON.stringify(blob);
+    if (json === this.lastProcessedJson) {
+      // Skip identical state broadcasts to avoid continuous re-renders.
+      return;
+    }
+    this.lastProcessedJson = json;
+    this.targetStateBlob.set(blob);
+
     if (this.reducedMotion || !blob || this.shouldJump(blob)) {
       this.jumpTo(blob);
       return;
     }
     const events = this.buildEvents(blob);
     if (events.length === 0) {
-      this.displayedStateBlob.set(clone(blob));
+      if (json !== JSON.stringify(this.displayedStateBlob())) {
+        this.displayedStateBlob.set(clone(blob));
+      }
       this.stage.set('idle');
       return;
     }

--- a/src/frontend/src/app/features/blackjack/blackjack.css
+++ b/src/frontend/src/app/features/blackjack/blackjack.css
@@ -126,13 +126,14 @@
 .bj-felt {
   border-radius: 50% / 38%;
   background:
-    radial-gradient(ellipse 72% 66% at 50% 44%, #4a7f4e 0%, var(--felt) 46%, var(--felt-dark) 100%);
+    radial-gradient(ellipse 78% 72% at 50% 40%, #4f8a54 0%, var(--felt) 42%, var(--felt-mid) 68%, var(--felt-dark) 100%);
   box-shadow:
-    0 0 0 5px  var(--rail-lo),
-    0 0 0 16px var(--rail),
-    0 0 0 21px var(--rail-hi),
-    0 0 0 25px var(--rail-lo),
-    0 14px 42px rgba(0,0,0,0.40),
+    0 0 0 4px  var(--rail-lo),
+    0 0 0 10px var(--rail),
+    0 0 0 14px var(--rail-hi),
+    0 0 0 18px var(--rail-lo),
+    0 0 0 22px rgba(0,0,0,0.25),
+    0 18px 50px rgba(0,0,0,0.45),
     inset 0 2px 14px rgba(0,0,0,0.20);
 }
 
@@ -159,6 +160,26 @@
   z-index: 2;
 }
 
+/* Spotlight overlay */
+.bj-felt__spotlight {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: radial-gradient(ellipse 55% 45% at 50% 30%, rgba(255,255,255,0.08) 0%, transparent 60%);
+  pointer-events: none;
+  z-index: 1;
+}
+
+/* Vignette overlay */
+.bj-felt__vignette {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: radial-gradient(ellipse 80% 80% at 50% 50%, transparent 45%, rgba(0,0,0,0.35) 100%);
+  pointer-events: none;
+  z-index: 2;
+}
+
 /* Center table branding */
 .bj-felt__brand {
   position: absolute;
@@ -166,14 +187,15 @@
   left: 50%;
   transform: translate(-50%, -50%);
   font-family: var(--font-display);
-  font-size: clamp(1.2rem, 3vw, 2.2rem);
+  font-size: clamp(1.4rem, 3.2vw, 2.6rem);
   font-weight: 700;
-  color: rgba(255,255,255,0.06);
+  color: rgba(255,255,255,0.08);
   text-transform: uppercase;
-  letter-spacing: 0.15em;
+  letter-spacing: 0.18em;
   pointer-events: none;
   z-index: 1;
   white-space: nowrap;
+  text-shadow: 0 1px 0 rgba(0,0,0,0.08);
 }
 
 /* Dealer positioning */
@@ -182,6 +204,55 @@
   top: 8%;
   left: 50%;
   transform: translateX(-50%);
+}
+
+.bj-dealer__spotlight {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 220px;
+  height: 120px;
+  transform: translate(-50%, -30%);
+  background: radial-gradient(ellipse 50% 50% at 50% 50%, rgba(255,255,255,0.10) 0%, transparent 70%);
+  pointer-events: none;
+  z-index: -1;
+}
+
+.bj-dealer__plate {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 3px 10px 3px 14px;
+  border-radius: 999px;
+  background: rgba(0,0,0,0.35);
+  border: 1px solid rgba(255,255,255,0.12);
+  backdrop-filter: blur(6px);
+}
+
+.bj-dealer__label {
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: rgba(255,255,255,0.70);
+}
+
+.bj-dealer__button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--gold);
+  color: #1a1200;
+  font-size: 0.6rem;
+  font-weight: 800;
+}
+
+.bj-dealer__value {
+  margin-top: 2px;
 }
 
 /* Insurance text */
@@ -197,32 +268,73 @@
   border: 1px solid rgba(255,255,255,0.06);
 }
 
-/* Cards */
-.bj-card {
+/* 3D Card flip */
+.card-flip {
+  perspective: 800px;
   animation: card-deal-in 0.45s cubic-bezier(0.22, 1, 0.36, 1) both;
-  border-radius: 8px;
-  box-shadow: 0 3px 10px rgba(0,0,0,0.35), 0 1px 3px rgba(0,0,0,0.25);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-.bj-card:hover {
-  transform: translateY(-4px) rotate(-1deg);
-  box-shadow: 0 8px 20px rgba(0,0,0,0.40), 0 2px 6px rgba(0,0,0,0.30);
+  flex-shrink: 0;
 }
 
-.bj-card--dealer {
+.card-flip--dealer {
   width: clamp(75px, 10%, 110px);
   aspect-ratio: 2.5 / 3.5;
 }
 
-.bj-card--player {
+.card-flip--player {
   width: clamp(65px, 9%, 95px);
   aspect-ratio: 2.5 / 3.5;
+}
+
+.card-flip__inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  transform-style: preserve-3d;
+  transition: transform 0.55s cubic-bezier(0.22, 1, 0.36, 1);
+  border-radius: 8px;
+  box-shadow: 0 3px 10px rgba(0,0,0,0.35), 0 1px 3px rgba(0,0,0,0.25);
+}
+
+.card-flip.face-down .card-flip__inner { transform: rotateY(180deg); }
+.card-flip.face-up   .card-flip__inner { transform: rotateY(0deg); }
+
+.card-flip.face-down:hover .card-flip__inner { transform: translateY(-4px) rotateY(180deg); }
+.card-flip.face-up:hover   .card-flip__inner { transform: translateY(-4px) rotateY(0deg); }
+
+.card-flip__front,
+.card-flip__back {
+  position: absolute;
+  inset: 0;
+  backface-visibility: hidden;
+  border-radius: 8px;
+  overflow: hidden;
+  background: transparent;
+}
+
+.card-flip__back {
+  transform: rotateY(180deg);
+}
+
+.card-flip__img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.card-flip:hover .card-flip__inner {
+  box-shadow: 0 8px 20px rgba(0,0,0,0.40), 0 2px 6px rgba(0,0,0,0.30);
 }
 
 /* Seats */
 .bj-seat {
   position: absolute;
   transform: translate(-50%, -50%);
+  transition: opacity 0.3s ease;
+}
+
+.bj-seat--inactive {
+  opacity: 0.75;
 }
 
 .bj-seat__plate {
@@ -230,9 +342,29 @@
   box-shadow: 0 2px 8px rgba(0,0,0,0.12), inset 0 1px 0 rgba(255,255,255,0.05);
 }
 
+.bj-seat__turn-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--gold);
+  box-shadow: 0 0 6px var(--gold);
+  animation: pulse-dot 1.2s ease-in-out infinite;
+}
+
 .bj-seat--hero .bj-seat__plate {
   border-color: var(--orange);
   box-shadow: 0 0 0 1px rgba(200, 86, 26, 0.25), 0 4px 12px rgba(200, 86, 26, 0.15);
+}
+
+/* Hero cards are lifted above the name plate so they aren't hidden behind the control bar */
+.bj-seat--hero .bj-seat__hands {
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  width: max-content;
+  margin-bottom: 0.5rem;
+  z-index: 11;
 }
 
 .bj-seat--active .bj-seat__plate {
@@ -246,17 +378,116 @@
   50%       { box-shadow: 0 0 0 6px rgba(200, 136, 26, 0.15); }
 }
 
-/* Hand value badge base */
+@keyframes pulse-dot {
+  0%, 100% { opacity: 0.7; transform: scale(0.9); }
+  50%       { opacity: 1; transform: scale(1.1); }
+}
+
+/* Hands */
+.bj-hand {
+  position: relative;
+  padding: 4px;
+  border-radius: 12px;
+  transition: background 0.25s ease;
+}
+
+.bj-hand--active {
+  background: rgba(200, 136, 26, 0.12);
+  box-shadow: 0 0 0 2px rgba(200, 136, 26, 0.35), inset 0 1px 0 rgba(255,255,255,0.05);
+  animation: hand-ring-pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes hand-ring-pulse {
+  0%, 100% { box-shadow: 0 0 0 2px rgba(200, 136, 26, 0.35); }
+  50%       { box-shadow: 0 0 0 5px rgba(200, 136, 26, 0.15); }
+}
+
+.bj-hand__arrow {
+  color: var(--gold);
+  filter: drop-shadow(0 0 4px rgba(200, 136, 26, 0.6));
+  animation: arrow-bob 1s ease-in-out infinite;
+  margin-bottom: -2px;
+}
+
+@keyframes arrow-bob {
+  0%, 100% { transform: translateY(0); }
+  50%       { transform: translateY(-3px); }
+}
+
+/* Bet circle & chips */
+.bj-bet {
+  position: relative;
+  width: 52px;
+  height: 52px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 4px;
+}
+
+.bj-bet__circle {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  border: 2px dashed rgba(255,255,255,0.25);
+  background: rgba(0,0,0,0.12);
+  box-shadow: inset 0 2px 8px rgba(0,0,0,0.15);
+}
+
+.bj-bet__stack {
+  position: relative;
+  width: 32px;
+  height: 32px;
+  z-index: 2;
+}
+
+.bj-chip {
+  position: absolute;
+  bottom: calc(var(--chip-index, 0) * 5px);
+  left: 50%;
+  width: 32px;
+  height: 32px;
+  transform: translateX(-50%);
+  border-radius: 50%;
+  border: 3px dashed rgba(255,255,255,0.7);
+  box-shadow: 0 2px 5px rgba(0,0,0,0.35), inset 0 1px 2px rgba(255,255,255,0.25);
+  animation: chip-place 0.35s cubic-bezier(0.22, 1, 0.36, 1) both;
+  animation-delay: calc(var(--chip-index, 0) * 60ms);
+}
+
+.bj-chip::after {
+  content: '';
+  position: absolute;
+  inset: 4px;
+  border-radius: 50%;
+  border: 1px solid rgba(255,255,255,0.4);
+}
+
+.chip--red    { background: radial-gradient(circle at 30% 30%, #ff6b6b, #c62828); }
+.chip--blue   { background: radial-gradient(circle at 30% 30%, #64b5f6, #1565c0); }
+.chip--green  { background: radial-gradient(circle at 30% 30%, #81c784, #2e7d32); }
+.chip--black  { background: radial-gradient(circle at 30% 30%, #757575, #212121); }
+.chip--gold   { background: radial-gradient(circle at 30% 30%, #ffd54f, #c8881a); }
+
+.bj-bet__amount {
+  position: absolute;
+  bottom: -10px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  color: rgba(255,255,255,0.9);
+  text-shadow: 0 1px 3px rgba(0,0,0,0.5);
+  white-space: nowrap;
+}
+
+@keyframes chip-place {
+  0%   { transform: translateX(-50%) translateY(-30px) scale(0.6); opacity: 0; }
+  100% { transform: translateX(-50%) translateY(0) scale(1); opacity: 1; }
+}
+
+/* Hand value badge */
 .bj-hand__value {
   color: #2a6832;
   background: rgba(250, 246, 241, 0.90);
-}
-
-/* Hand states */
-.bj-hand--active {
-  background: rgba(200, 136, 26, 0.12);
-  border-radius: 10px;
-  padding: 4px;
 }
 
 .bj-hand__value--bust {
@@ -269,14 +500,37 @@
   background: rgba(255, 248, 225, 0.90);
 }
 
-/* Controls */
-.bj-controls__message {
-  animation: pulse-text 1.5s ease-in-out infinite;
+.bj-hand__value--win {
+  color: #2a6832;
+  background: rgba(232, 245, 233, 0.90);
 }
 
-@keyframes pulse-text {
-  0%, 100% { opacity: 0.6; }
-  50%       { opacity: 1; }
+.bj-hand__value--lose {
+  color: #c62828;
+  background: rgba(255, 235, 238, 0.90);
+}
+
+.bj-hand__value--push {
+  color: #6b6b6b;
+  background: rgba(245, 245, 245, 0.90);
+}
+
+/* Floating Control Bar */
+.bj-control-bar {
+  width: max-content;
+  max-width: min(90%, 560px);
+}
+
+.bj-control-bar__panel {
+  background: rgba(20, 30, 20, 0.72);
+  border: 1px solid rgba(255,255,255,0.12);
+  border-radius: 18px;
+  backdrop-filter: blur(16px);
+  box-shadow: 0 12px 40px rgba(0,0,0,0.40), inset 0 1px 0 rgba(255,255,255,0.08);
+}
+
+.bj-control-bar__panel--message {
+  background: rgba(20, 30, 20, 0.60);
 }
 
 /* Buttons */
@@ -328,17 +582,51 @@
   transform: translateY(-1px);
 }
 
+.bj-btn--round {
+  width: 68px;
+  height: 68px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  text-align: center;
+}
+
+.bj-btn--chip {
+  border-radius: 999px;
+  box-shadow: 0 6px 22px rgba(200, 86, 26, 0.45), inset 0 1px 0 rgba(255,255,255,0.18);
+}
+
+.bj-btn__label {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  line-height: 1.1;
+  font-size: 0.8rem;
+  font-weight: 800;
+}
+
 .bj-btn:active { transform: scale(0.96) translateY(0); }
 .bj-btn:disabled { opacity: 0.4; cursor: not-allowed; transform: none; }
 .bj-btn--full { width: 100%; margin-top: 4px; }
 
-/* Bet slider */
+.bj-controls__message {
+  animation: pulse-text 1.5s ease-in-out infinite;
+}
+
+@keyframes pulse-text {
+  0%, 100% { opacity: 0.6; }
+  50%       { opacity: 1; }
+}
+
+/* Bet slider inside glass bar */
 .bj-bet-slider__input {
   -webkit-appearance: none;
   appearance: none;
   height: 6px;
   border-radius: 3px;
-  background: var(--border);
+  background: rgba(255,255,255,0.20);
   outline: none;
 }
 
@@ -348,7 +636,7 @@
   width: 20px;
   height: 20px;
   border-radius: 50%;
-  background: var(--orange);
+  background: var(--gold);
   border: 2px solid #ffffff;
   box-shadow: 0 2px 6px rgba(0,0,0,0.25);
   cursor: pointer;
@@ -356,7 +644,7 @@
 }
 
 .bj-bet-slider__input::-webkit-slider-thumb:hover {
-  background: var(--orange-light);
+  background: #fbbf24;
   transform: scale(1.1);
 }
 
@@ -364,10 +652,28 @@
   width: 20px;
   height: 20px;
   border-radius: 50%;
-  background: var(--orange);
+  background: var(--gold);
   border: 2px solid #ffffff;
   box-shadow: 0 2px 6px rgba(0,0,0,0.25);
   cursor: pointer;
+}
+
+/* Start hint */
+.bj-start-hint {
+  background: rgba(0,0,0,0.45);
+  border: 1px solid rgba(255,255,255,0.10);
+  border-radius: 999px;
+  padding: 6px 16px;
+  backdrop-filter: blur(8px);
+  color: rgba(255,255,255,0.85);
+  font-size: 0.8rem;
+  font-weight: 600;
+  animation: hint-pulse 2s ease-in-out infinite;
+}
+
+@keyframes hint-pulse {
+  0%, 100% { opacity: 0.7; }
+  50%       { opacity: 1; }
 }
 
 /* Announcement */
@@ -378,7 +684,14 @@
 .bj-announcement__text {
   font-family: var(--font-display);
   font-size: clamp(2.5rem, 10vw, 6rem);
-  text-shadow: 0 0 50px rgba(200, 86, 26, 0.50), 0 4px 16px rgba(0,0,0,0.55);
+  font-weight: 700;
+  color: #ffffff;
+  text-align: center;
+  letter-spacing: 0.04em;
+  text-shadow:
+    0 0 40px rgba(200, 136, 26, 0.55),
+    0 0 80px rgba(200, 86, 26, 0.35),
+    0 4px 16px rgba(0,0,0,0.55);
   animation: text-lifecycle 1.8s ease-in-out forwards;
 }
 
@@ -400,6 +713,24 @@
   0%   { transform: scale(0.35) rotate(-18deg); opacity: 0; }
   60%  { transform: scale(1.06) rotate(2deg); opacity: 1; }
   100% { transform: scale(1) rotate(0deg); opacity: 1; }
+}
+
+/* Waiting / empty overlay */
+.bj-waiting {
+  animation: fade-in 0.35s ease both;
+}
+
+.bj-waiting__panel {
+  background: linear-gradient(160deg, var(--bg-card) 0%, var(--bg-sidebar) 100%);
+  border: 1px solid var(--border);
+  box-shadow: 0 24px 70px rgba(0,0,0,0.35);
+  max-width: min(90%, 360px);
+}
+
+.bj-waiting__icon {
+  font-size: 3rem;
+  line-height: 1;
+  filter: drop-shadow(0 4px 8px rgba(0,0,0,0.15));
 }
 
 /* Results overlay */
@@ -424,6 +755,44 @@
   background-clip: text;
 }
 
+.bj-result-row {
+  background: var(--bg-card);
+}
+
+.bj-result-row--result--win,
+.bj-result-row--result--blackjack {
+  border-color: rgba(74, 222, 128, 0.35);
+  background: rgba(74, 222, 128, 0.06);
+}
+
+.bj-result-row--result--lose,
+.bj-result-row--result--bust {
+  border-color: rgba(239, 83, 80, 0.25);
+  background: rgba(239, 83, 80, 0.05);
+}
+
+.bj-result-row--result--push {
+  border-color: var(--border);
+}
+
+.bj-result-row__label--result--win,
+.bj-result-row__label--result--blackjack {
+  color: #2a6832;
+}
+
+.bj-result-row__label--result--lose,
+.bj-result-row__label--result--bust {
+  color: #c62828;
+}
+
+.bj-result-row__label--result--push {
+  color: var(--text-muted);
+}
+
+.bj-overlay__winner-chip {
+  animation: chip-place 0.35s ease both;
+}
+
 .bj-overlay__btn {
   font-family: var(--font-ui);
   transition: background 0.18s, transform 0.10s, box-shadow 0.18s;
@@ -443,6 +812,72 @@
   to   { opacity: 1; transform: scale(1) translateY(0); }
 }
 
+/* Mobile bottom bar */
+.bj-mobile-bar {
+  display: none;
+}
+
+/* Responsive */
+@media (max-width: 900px) {
+  .bj-main { grid-template-columns: 1fr; grid-template-rows: 1fr; }
+  .bj-sidebar { position: absolute; opacity: 0; pointer-events: none; }
+  .bj-wrapper { width: min(95vw, 700px); aspect-ratio: 1.2 / 1; }
+  .card-flip--dealer { width: clamp(60px, 9%, 90px); }
+  .card-flip--player { width: clamp(50px, 8%, 75px); }
+  .bj-mobile-bar { display: grid; }
+  .bj-page { padding-bottom: 64px; }
+  .bj-control-bar__panel { padding: 12px 16px; }
+  .bj-btn--round { width: 58px; height: 58px; }
+  .bj-btn__label { font-size: 0.7rem; }
+}
+
+@media (max-width: 600px) {
+  .bj-title { font-size: 1.3rem; }
+  .bj-wrapper { width: min(98vw, 560px); aspect-ratio: 1 / 1.1; }
+  .card-flip--dealer { width: clamp(50px, 8%, 70px); }
+  .card-flip--player { width: clamp(42px, 7%, 60px); }
+  .bj-overlay__panel { padding: 28px 24px; min-width: 260px; }
+  .bj-seat__plate { min-width: 60px; padding: 2px 6px; }
+  .bj-seat__name { max-width: 70px; font-size: 10px; }
+  .bj-seat__chips { font-size: 10px; }
+  .bj-bet { width: 42px; height: 42px; }
+  .bj-bet__circle { border-width: 1px; }
+  .bj-chip { width: 26px; height: 26px; border-width: 2px; }
+  .bj-bet__amount { font-size: 0.6rem; bottom: -8px; }
+  .bj-control-bar { bottom: 2%; }
+  .bj-control-bar__panel--betting { min-width: 180px; }
+  .bj-btn--round { width: 50px; height: 50px; }
+  .bj-btn__label { font-size: 0.65rem; }
+  .bj-dealer__spotlight { width: 160px; height: 90px; }
+}
+
+/* prefers-reduced-motion */
+@media (prefers-reduced-motion: reduce) {
+  .card-flip__inner { transition: none; }
+  .card-flip,
+  .bj-chip,
+  .bj-seat--active .bj-seat__plate,
+  .bj-hand--active,
+  .bj-hand__arrow,
+  .bj-controls__message,
+  .bj-announcement,
+  .bj-announcement__text,
+  .bj-overlay,
+  .bj-overlay__panel,
+  .bj-waiting,
+  .bj-start-hint,
+  .bj-overlay__winner-chip {
+    animation: none !important;
+  }
+  .bj-seat--active .bj-seat__plate,
+  .bj-hand--active {
+    box-shadow: 0 0 0 3px rgba(200, 136, 26, 0.35);
+  }
+  .card-flip.face-down .card-flip__inner { transform: rotateY(180deg); }
+  .card-flip.face-up .card-flip__inner { transform: rotateY(0deg); }
+}
+
+/* Dark mode */
 :host-context(body.theme-dark) {
   --bg-page:       #1a1a1a;
   --bg-sidebar:    #2a2a2a;
@@ -475,14 +910,21 @@
   background: rgba(255, 255, 255, 0.10);
 }
 
-:host-context(body.theme-dark) .bj-hand__value--bust {
+:host-context(body.theme-dark) .bj-hand__value--bust,
+:host-context(body.theme-dark) .bj-hand__value--lose {
   color: #ff6b6b;
   background: rgba(229, 57, 53, 0.20);
 }
 
-:host-context(body.theme-dark) .bj-hand__value--blackjack {
+:host-context(body.theme-dark) .bj-hand__value--blackjack,
+:host-context(body.theme-dark) .bj-hand__value--win {
   color: #fbbf24;
   background: rgba(245, 158, 11, 0.20);
+}
+
+:host-context(body.theme-dark) .bj-hand__value--push {
+  color: #aaaaaa;
+  background: rgba(255, 255, 255, 0.08);
 }
 
 :host-context(body.theme-dark) .bj-table-area::before {
@@ -500,19 +942,17 @@
   box-shadow: 0 4px 14px rgba(0,0,0,0.25);
 }
 
-/* Responsive */
-@media (max-width: 900px) {
-  .bj-main { grid-template-columns: 1fr; grid-template-rows: auto 1fr; }
-  .bj-sidebar { display: none; }
-  .bj-wrapper { width: min(95vw, 700px); aspect-ratio: 1.2 / 1; }
-  .bj-card--dealer { width: clamp(60px, 9%, 90px); }
-  .bj-card--player { width: clamp(50px, 8%, 75px); }
+:host-context(body.theme-dark) .bj-control-bar__panel {
+  background: rgba(10, 15, 10, 0.78);
+  border-color: rgba(255,255,255,0.08);
 }
 
-@media (max-width: 600px) {
-  .bj-title { font-size: 1.3rem; }
-  .bj-wrapper { aspect-ratio: 1 / 1.1; }
-  .bj-card--dealer { width: clamp(50px, 8%, 70px); }
-  .bj-card--player { width: clamp(42px, 7%, 60px); }
-  .bj-overlay__panel { padding: 28px 24px; min-width: 260px; }
+:host-context(body.theme-dark) .bj-result-row--result--win,
+:host-context(body.theme-dark) .bj-result-row--result--blackjack {
+  background: rgba(74, 222, 128, 0.10);
+}
+
+:host-context(body.theme-dark) .bj-result-row--result--lose,
+:host-context(body.theme-dark) .bj-result-row--result--bust {
+  background: rgba(239, 83, 80, 0.10);
 }

--- a/src/frontend/src/app/features/blackjack/blackjack.css
+++ b/src/frontend/src/app/features/blackjack/blackjack.css
@@ -401,6 +401,24 @@
   animation: hand-ring-pulse 1.5s ease-in-out infinite;
 }
 
+.bj-hand--win {
+  outline: 2px solid rgba(74, 222, 128, 0.6);
+  outline-offset: 2px;
+  border-radius: 12px;
+}
+
+.bj-hand--lose {
+  outline: 2px solid rgba(239, 83, 80, 0.5);
+  outline-offset: 2px;
+  border-radius: 12px;
+}
+
+.bj-hand--push {
+  outline: 2px solid var(--border);
+  outline-offset: 2px;
+  border-radius: 12px;
+}
+
 @keyframes hand-ring-pulse {
   0%, 100% { box-shadow: 0 0 0 2px rgba(200, 136, 26, 0.35); }
   50%       { box-shadow: 0 0 0 5px rgba(200, 136, 26, 0.15); }
@@ -472,6 +490,26 @@
 .chip--green  { background: radial-gradient(circle at 30% 30%, #81c784, #2e7d32); }
 .chip--black  { background: radial-gradient(circle at 30% 30%, #757575, #212121); }
 .chip--gold   { background: radial-gradient(circle at 30% 30%, #ffd54f, #c8881a); }
+
+.bj-hand--win .bj-chip,
+.bj-hand--blackjack .bj-chip {
+  animation: chip-payout 0.65s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+
+@keyframes chip-payout {
+  0% {
+    transform: translateX(-50%) translateY(0) scale(1);
+    opacity: 1;
+  }
+  60% {
+    transform: translateX(-50%) translateY(-28px) scale(1.1);
+    opacity: 1;
+  }
+  100% {
+    transform: translateX(-50%) translateY(-40px) scale(0.85);
+    opacity: 0;
+  }
+}
 
 .bj-bet__amount {
   position: absolute;

--- a/src/frontend/src/app/features/blackjack/blackjack.css
+++ b/src/frontend/src/app/features/blackjack/blackjack.css
@@ -271,8 +271,12 @@
 /* 3D Card flip */
 .card-flip {
   perspective: 800px;
-  animation: card-deal-in 0.45s cubic-bezier(0.22, 1, 0.36, 1) both;
   flex-shrink: 0;
+}
+
+/* Only newly entering cards animate */
+.card-flip--entering {
+  animation: card-deal-in 0.45s cubic-bezier(0.22, 1, 0.36, 1) both;
 }
 
 .card-flip--dealer {

--- a/src/frontend/src/app/features/blackjack/blackjack.html
+++ b/src/frontend/src/app/features/blackjack/blackjack.html
@@ -9,11 +9,17 @@
     >
       {{ phaseLabel() }}
     </span>
+    <div class="bj-header__meta hidden md:flex items-center justify-end gap-4 text-[0.8rem] text-[var(--text-muted)]">
+      @if (heroPlayer(); as hero) {
+        <span class="tabular-nums font-semibold text-[var(--orange)]">{{ hero.chips }} chips</span>
+      }
+      <span class="tabular-nums">Min: {{ minBet() }}</span>
+    </div>
   </header>
 
   <!-- Phase Announcement -->
   @if (showAnnouncement()) {
-    <div class="bj-announcement fixed inset-0 z-[150] flex items-center justify-center bg-black/50 pointer-events-none" role="status" aria-live="assertive">
+    <div class="bj-announcement fixed inset-0 z-[150] flex items-center justify-center bg-black/55 pointer-events-none" role="status" aria-live="assertive">
       <span class="bj-announcement__text">{{ announcementText() }}</span>
     </div>
   }
@@ -48,20 +54,38 @@
       <div class="bj-wrapper relative w-full flex flex-col items-center gap-4">
         <!-- Felt Table -->
         <div class="bj-felt relative w-full h-full overflow-hidden">
+          <!-- Spotlight & vignette overlays -->
+          <div class="bj-felt__spotlight"></div>
+          <div class="bj-felt__vignette"></div>
+
           <!-- Table Brand -->
           <div class="bj-felt__brand">Ember Exchange</div>
 
           <!-- Dealer -->
           <div class="bj-dealer absolute top-[8%] left-1/2 -translate-x-1/2 flex flex-col items-center gap-2.5 z-[5]">
-            <div class="bj-dealer__label text-[0.7rem] font-bold uppercase tracking-[0.14em] text-white/[0.55]">Dealer</div>
+            <div class="bj-dealer__spotlight"></div>
+            <div class="bj-dealer__plate">
+              <span class="bj-dealer__label">Dealer</span>
+              <span class="bj-dealer__button">D</span>
+            </div>
             <div class="bj-dealer__cards flex gap-2.5">
               @for (card of dealerHand(); track $index) {
-                <div class="bj-card bj-card--dealer overflow-hidden shrink-0 leading-none">
-                  @if (card.faceUp) {
-                    <img [src]="cardSpriteSrc(card)" [alt]="card.rank + ' of ' + card.suit" class="bj-card-img w-full h-full object-cover block" />
-                  } @else {
-                    <img [src]="cardBackSrc()" alt="Hidden card" class="bj-card-img w-full h-full object-cover block" />
-                  }
+                <div
+                  class="card-flip card-flip--dealer"
+                  [class.face-down]="!card.faceUp"
+                  [class.face-up]="card.faceUp"
+                  [class.card-flip--entering]="enteringCardIds().has(card.cardId)"
+                >
+                  <div class="card-flip__inner">
+                    <div class="card-flip__front">
+                      @if (card.faceUp) {
+                        <img [src]="cardSpriteSrc(card)" [alt]="card.rank + ' of ' + card.suit" class="card-flip__img" />
+                      }
+                    </div>
+                    <div class="card-flip__back">
+                      <img [src]="cardBackSrc()" alt="Hidden card" class="card-flip__img" />
+                    </div>
+                  </div>
                 </div>
               }
             </div>
@@ -70,7 +94,7 @@
             }
           </div>
 
-          <!-- Insurance marker (decorative) -->
+          <!-- Insurance marker -->
           <div class="bj-insurance absolute top-[42%] left-1/2 -translate-x-1/2 font-semibold tracking-[0.14em] uppercase text-white/[0.18] whitespace-nowrap pointer-events-none z-[1]">Insurance pays 2:1</div>
 
           <!-- Player Seats -->
@@ -80,38 +104,81 @@
                 class="bj-seat absolute flex flex-col items-center gap-1.5 z-10"
                 [class.bj-seat--hero]="isHeroSeat(i)"
                 [class.bj-seat--active]="player.isCurrentTurn"
+                [class.bj-seat--inactive]="!player.isCurrentTurn && (isPlaying() || isDealerTurn())"
                 [style.left.%]="seatPositions[i].x"
                 [style.top.%]="seatPositions[i].y"
               >
                 <!-- Name plate -->
                 <div class="bj-seat__plate flex flex-col items-center bg-[var(--seat-bg)] border border-[var(--seat-border)] rounded-lg px-2.5 py-1 min-w-[70px] text-center backdrop-blur-sm">
-                  <span class="bj-seat__name text-[11px] font-bold text-[var(--text-primary)] whitespace-nowrap overflow-hidden text-ellipsis max-w-[90px]">{{ player.name }}</span>
+                  <div class="flex items-center gap-1">
+                    @if (player.isCurrentTurn) {
+                      <span class="bj-seat__turn-dot"></span>
+                    }
+                    <span class="bj-seat__name text-[11px] font-bold text-[var(--text-primary)] whitespace-nowrap overflow-hidden text-ellipsis max-w-[90px]">{{ player.name }}</span>
+                  </div>
                   <span class="bj-seat__chips text-[11px] font-semibold text-[var(--orange)] tabular-nums">{{ player.chips }}</span>
                 </div>
 
                 <!-- Hands -->
                 <div class="bj-seat__hands flex flex-col items-center gap-2">
                   @for (hand of player.hands; track hand.handId) {
-                    <div class="bj-hand flex flex-col items-center gap-1" [class.bj-hand--active]="hand.isCurrentTurn">
+                    <div
+                      class="bj-hand flex flex-col items-center gap-1"
+                      [class.bj-hand--active]="hand.isCurrentTurn"
+                      [class.bj-hand--settled]="isShowdown()"
+                      [class.bj-hand--win]="hand.status === 'win' || hand.status === 'blackjack'"
+                      [class.bj-hand--lose]="hand.status === 'lose' || hand.status === 'bust'"
+                      [class.bj-hand--push]="hand.status === 'push'"
+                    >
+                      <!-- Bet circle with chips -->
+                      @if (hand.bet > 0) {
+                        <div class="bj-bet">
+                          <div class="bj-bet__circle"></div>
+                          <div class="bj-bet__stack">
+                            @for (chip of chipStack(hand.bet); track $index) {
+                              <div class="bj-chip" [class]="chip" [style.--chip-index]="$index"></div>
+                            }
+                          </div>
+                          <span class="bj-bet__amount">{{ hand.bet }}</span>
+                        </div>
+                      }
+
+                      <!-- Active-hand indicator -->
+                      @if (hand.isCurrentTurn) {
+                        <div class="bj-hand__arrow">
+                          <svg viewBox="0 0 24 24" fill="currentColor" class="w-4 h-4"><path d="M12 21l-12-18h24z"/></svg>
+                        </div>
+                      }
+
                       <div class="bj-hand__cards flex gap-1.5">
                         @for (card of hand.cards; track $index) {
-                          <div class="bj-card bj-card--player overflow-hidden shrink-0 leading-none">
-                            @if (card.faceUp) {
-                              <img [src]="cardSpriteSrc(card)" [alt]="card.rank + ' of ' + card.suit" class="bj-card-img w-full h-full object-cover block" />
-                            } @else {
-                              <img [src]="cardBackSrc()" alt="Hidden card" class="bj-card-img w-full h-full object-cover block" />
-                            }
+                          <div
+                            class="card-flip card-flip--player"
+                            [class.face-down]="!card.faceUp"
+                            [class.face-up]="card.faceUp"
+                            [class.card-flip--entering]="enteringCardIds().has(card.cardId)"
+                          >
+                            <div class="card-flip__inner">
+                              <div class="card-flip__front">
+                                @if (card.faceUp) {
+                                  <img [src]="cardSpriteSrc(card)" [alt]="card.rank + ' of ' + card.suit" class="card-flip__img" />
+                                }
+                              </div>
+                              <div class="card-flip__back">
+                                <img [src]="cardBackSrc()" alt="Hidden card" class="card-flip__img" />
+                              </div>
+                            </div>
                           </div>
                         }
                       </div>
                       <div class="bj-hand__meta flex gap-2 items-center text-[0.75rem]">
-                        @if (hand.bet > 0) {
-                          <span class="bj-hand__bet text-white/70 font-semibold">Bet: {{ hand.bet }}</span>
-                        }
                         <span
                           class="bj-hand__value font-bold px-2 py-0.5 rounded-lg"
                           [class.bj-hand__value--bust]="hand.status === 'bust'"
                           [class.bj-hand__value--blackjack]="hand.status === 'blackjack'"
+                          [class.bj-hand__value--win]="hand.status === 'win'"
+                          [class.bj-hand__value--lose]="hand.status === 'lose'"
+                          [class.bj-hand__value--push]="hand.status === 'push'"
                         >
                           {{ getHandValueDisplay(hand) }}
                         </span>
@@ -122,57 +189,83 @@
               </div>
             }
           }
-        </div>
 
-        <!-- Controls -->
-        <div class="bj-controls flex justify-center items-center min-h-[56px] gap-3 mt-4.5">
-          @if (isBetting() && canAction('bet')) {
-            <div class="bj-controls__group bj-controls__group--betting flex flex-col items-center gap-2.5">
-              <div class="bj-bet-slider flex flex-col items-center gap-1.5 min-w-[200px]">
-                <span class="bj-bet-slider__label text-base font-bold text-[var(--text-primary)]">Bet: {{ betAmount() }}</span>
-                <input
-                  type="range"
-                  class="bj-bet-slider__input w-full h-1.5 rounded-[3px] bg-[var(--border)] outline-none cursor-pointer"
-                  [min]="minBet()"
-                  [max]="maxBet()"
-                  [step]="10"
-                  [value]="betAmount()"
-                  (input)="betAmount.set(+$any($event.target).value)"
-                />
-                <div class="bj-bet-slider__range flex justify-between w-full text-[0.75rem] font-semibold text-[var(--text-muted)]">
-                  <span>{{ minBet() }}</span>
-                  <span>{{ maxBet() }}</span>
+          <!-- Floating Control Bar -->
+          <div class="bj-control-bar absolute bottom-[4%] left-1/2 -translate-x-1/2 z-20">
+            @if (isAnimating()) {
+              <div class="bj-control-bar__panel bj-control-bar__panel--message px-6 py-3">
+                <span class="bj-controls__message text-base font-semibold text-white/80 italic">{{ stageMessage() }}</span>
+              </div>
+            } @else {
+              @if (isBetting() && canAction('bet')) {
+                <div class="bj-control-bar__panel bj-control-bar__panel--betting flex flex-col items-center gap-3 px-6 py-4">
+                  <div class="flex flex-col items-center gap-1.5 w-full min-w-[220px]">
+                    <div class="flex items-center justify-between w-full">
+                      <span class="text-[0.75rem] font-semibold uppercase tracking-wider text-white/70">Bet</span>
+                      <span class="text-xl font-bold text-[var(--gold)] tabular-nums">{{ betAmount() }}</span>
+                    </div>
+                    <input
+                      type="range"
+                      class="bj-bet-slider__input w-full h-1.5 rounded-[3px] bg-white/20 outline-none cursor-pointer"
+                      [min]="minBet()"
+                      [max]="maxBet()"
+                      [step]="10"
+                      [value]="betAmount()"
+                      (input)="betAmount.set(+$any($event.target).value)"
+                    />
+                    <div class="flex justify-between w-full text-[0.7rem] font-semibold text-white/50">
+                      <span>{{ minBet() }}</span>
+                      <span>{{ maxBet() }}</span>
+                    </div>
+                  </div>
+                  <button class="bj-btn bj-btn--primary bj-btn--chip py-3 px-8 rounded-full border-none text-[0.95rem] font-bold cursor-pointer" (click)="executeBet()">Place Bet</button>
                 </div>
-              </div>
-              <button class="bj-btn bj-btn--primary py-3 px-7 rounded-[10px] border-none text-[0.9rem] font-bold cursor-pointer" (click)="executeBet()">Place Bet</button>
-            </div>
-          }
-
-          @if (isInsurance() && isHeroTurn()) {
-            <div class="bj-controls__group flex flex-col items-center gap-2">
-              <span class="text-sm font-semibold text-[var(--text-muted)]">Dealer shows Ace — Take Insurance?</span>
-              <div class="flex items-center gap-3">
-                <button class="bj-btn bj-btn--highlight py-3 px-7 rounded-[10px] text-[0.9rem] font-bold cursor-pointer" (click)="executeInsurance()" [disabled]="!canAction('insurance')">Take Insurance</button>
-                <button class="bj-btn bj-btn--action py-3 px-7 rounded-[10px] text-[0.9rem] font-bold cursor-pointer" (click)="executeDeclineInsurance()" [disabled]="!canAction('decline_insurance')">Decline</button>
-              </div>
-            </div>
-          }
-
-          @if (isPlaying() && isHeroTurn()) {
-            <div class="bj-controls__group flex items-center gap-3">
-              <button class="bj-btn bj-btn--action py-3 px-7 rounded-[10px] text-[0.9rem] font-bold cursor-pointer" (click)="executeHit()" [disabled]="!canAction('hit')">Hit</button>
-              <button class="bj-btn bj-btn--action py-3 px-7 rounded-[10px] text-[0.9rem] font-bold cursor-pointer" (click)="executeStand()" [disabled]="!canAction('stand')">Stand</button>
-              @if (canAction('double')) {
-                <button class="bj-btn bj-btn--highlight py-3 px-7 rounded-[10px] text-[0.9rem] font-bold cursor-pointer" (click)="executeDouble()">Double</button>
               }
-              @if (canAction('split')) {
-                <button class="bj-btn bj-btn--highlight py-3 px-7 rounded-[10px] text-[0.9rem] font-bold cursor-pointer" (click)="executeSplit()">Split</button>
-              }
-            </div>
-          }
 
-          @if (isDealerTurn()) {
-            <div class="bj-controls__message text-base font-semibold text-[var(--text-muted)] italic">Dealer is drawing…</div>
+              @if (isInsurance() && isHeroTurn()) {
+                <div class="bj-control-bar__panel flex flex-col items-center gap-3 px-6 py-4">
+                  <span class="text-sm font-semibold text-white/90">Dealer shows Ace — Take Insurance?</span>
+                  <div class="flex items-center gap-3">
+                    <button class="bj-btn bj-btn--highlight py-3 px-6 rounded-full text-[0.9rem] font-bold cursor-pointer" (click)="executeInsurance()" [disabled]="!canAction('insurance')">Take Insurance</button>
+                    <button class="bj-btn bj-btn--action py-3 px-6 rounded-full text-[0.9rem] font-bold cursor-pointer" (click)="executeDeclineInsurance()" [disabled]="!canAction('decline_insurance')">Decline</button>
+                  </div>
+                </div>
+              }
+
+              @if (isPlaying() && isHeroTurn()) {
+                <div class="bj-control-bar__panel flex items-center gap-3 px-5 py-3">
+                  <button class="bj-btn bj-btn--action bj-btn--round" (click)="executeHit()" [disabled]="!canAction('hit')" title="Hit">
+                    <span class="bj-btn__label">Hit</span>
+                  </button>
+                  <button class="bj-btn bj-btn--action bj-btn--round" (click)="executeStand()" [disabled]="!canAction('stand')" title="Stand">
+                    <span class="bj-btn__label">Stand</span>
+                  </button>
+                  @if (canAction('double')) {
+                    <button class="bj-btn bj-btn--highlight bj-btn--round" (click)="executeDouble()" title="Double">
+                      <span class="bj-btn__label">Double</span>
+                    </button>
+                  }
+                  @if (canAction('split')) {
+                    <button class="bj-btn bj-btn--highlight bj-btn--round" (click)="executeSplit()" title="Split">
+                      <span class="bj-btn__label">Split</span>
+                    </button>
+                  }
+                </div>
+              }
+
+              @if (isDealerTurn()) {
+                <div class="bj-control-bar__panel bj-control-bar__panel--message px-6 py-3">
+                  <span class="bj-controls__message text-base font-semibold text-white/80 italic">Dealer is drawing…</span>
+                </div>
+              }
+            }
+          </div>
+
+          <!-- Start hint -->
+          @if (showStartHint()) {
+            <div class="bj-start-hint absolute top-[58%] left-1/2 -translate-x-1/2 z-10">
+              <span>Place your bet to start</span>
+            </div>
           }
         </div>
       </div>
@@ -218,5 +311,81 @@
         </div>
       }
     </aside>
+  </div>
+
+  <!-- Waiting / Empty overlay -->
+  @if (showWaitingOverlay()) {
+    <div class="bj-waiting fixed inset-0 z-[140] flex items-center justify-center bg-black/50 backdrop-blur-sm">
+      <div class="bj-waiting__panel flex flex-col items-center gap-4 px-8 py-10 rounded-2xl text-center">
+        <div class="bj-waiting__icon">🃏</div>
+        <h2 class="text-2xl font-bold text-[var(--text-primary)]" style="font-family: var(--font-display)">Waiting for players…</h2>
+        <p class="text-[0.9rem] text-[var(--text-muted)] max-w-[280px]">Grab a seat. The game starts once bets are placed.</p>
+      </div>
+    </div>
+  }
+
+  <!-- Results Overlay -->
+  @if (showResultsOverlay()) {
+    <div class="bj-overlay fixed inset-0 z-[160] flex items-center justify-center p-4">
+      <div class="bj-overlay__panel flex flex-col gap-5 px-8 py-8 rounded-2xl max-w-md w-full">
+        <h2 class="bj-overlay__title text-3xl font-bold text-center mb-1">Showdown</h2>
+
+        <div class="bj-overlay__results flex flex-col gap-2.5 max-h-[50vh] overflow-y-auto pr-1">
+          @for (row of resultRows(); track $index) {
+            <div class="bj-result-row flex items-center justify-between px-4 py-3 rounded-xl border" [class]="'bj-result-row--' + row.resultClass">
+              <div class="flex flex-col">
+                <span class="font-semibold text-[0.9rem] text-[var(--text-primary)]">{{ row.name }}</span>
+                @if (row.handName) {
+                  <span class="text-[0.75rem] text-[var(--text-muted)]">{{ row.handName }}</span>
+                }
+              </div>
+              <div class="flex flex-col items-end">
+                <span class="text-[0.75rem] font-bold uppercase tracking-wider" [class]="'bj-result-row__label--' + row.resultClass">{{ row.label }}</span>
+                <span class="text-[1rem] font-bold tabular-nums" [class]="row.amount >= 0 ? 'text-[var(--orange)]' : 'text-red-500'">
+                  {{ row.amount >= 0 ? '+' : '' }}{{ row.amount }}
+                </span>
+              </div>
+            </div>
+          } @empty {
+            <p class="text-center text-[var(--text-muted)] italic">No results to show.</p>
+          }
+        </div>
+
+        @if (winners().length > 0) {
+          <div class="bj-overlay__winners flex flex-wrap justify-center gap-2">
+            @for (winner of winners(); track $index) {
+              <div class="bj-overlay__winner-chip flex items-center gap-2 px-3 py-1.5 rounded-full border border-[var(--gold)] bg-[var(--gold-dim)]">
+                <span class="text-[0.8rem] font-semibold text-[var(--text-primary)]">{{ getPlayerName(winner.playerId) }}</span>
+                <span class="text-[0.8rem] font-bold text-[var(--orange)] tabular-nums">+{{ winner.amount }}</span>
+              </div>
+            }
+          </div>
+        }
+
+        @if (isHost()) {
+          <button class="bj-overlay__btn w-full py-3.5 px-7 rounded-xl border-none text-[0.95rem] font-bold cursor-pointer text-white" (click)="onNewRound()">Next Round</button>
+        }
+      </div>
+    </div>
+  }
+
+  <!-- Mobile / tablet compact info bar -->
+  <div class="bj-mobile-bar md:hidden fixed bottom-0 left-0 right-0 z-[120] grid grid-cols-3 gap-2 px-4 py-3 border-t border-[var(--border)] bg-[var(--bg-card)]/95 backdrop-blur-md">
+    <div class="flex flex-col items-center justify-center">
+      <span class="text-[0.65rem] uppercase tracking-wider text-[var(--text-muted)]">Phase</span>
+      <span class="text-[0.8rem] font-semibold text-[var(--text-primary)]">{{ phaseLabel() }}</span>
+    </div>
+    <div class="flex flex-col items-center justify-center">
+      <span class="text-[0.65rem] uppercase tracking-wider text-[var(--text-muted)]">Bet</span>
+      <span class="text-[0.8rem] font-bold text-[var(--orange)] tabular-nums">{{ currentBet() }}</span>
+    </div>
+    <div class="flex flex-col items-center justify-center">
+      <span class="text-[0.65rem] uppercase tracking-wider text-[var(--text-muted)]">Stack</span>
+      @if (heroPlayer(); as hero) {
+        <span class="text-[0.8rem] font-bold text-[var(--orange)] tabular-nums">{{ hero.chips }}</span>
+      } @else {
+        <span class="text-[0.8rem] font-bold text-[var(--text-muted)]">—</span>
+      }
+    </div>
   </div>
 </div>

--- a/src/frontend/src/app/features/blackjack/blackjack.html
+++ b/src/frontend/src/app/features/blackjack/blackjack.html
@@ -127,6 +127,7 @@
                       [class.bj-hand--active]="hand.isCurrentTurn"
                       [class.bj-hand--settled]="isShowdown()"
                       [class.bj-hand--win]="hand.status === 'win' || hand.status === 'blackjack'"
+                      [class.bj-hand--blackjack]="hand.status === 'blackjack'"
                       [class.bj-hand--lose]="hand.status === 'lose' || hand.status === 'bust'"
                       [class.bj-hand--push]="hand.status === 'push'"
                     >

--- a/src/frontend/src/app/features/blackjack/blackjack.ts
+++ b/src/frontend/src/app/features/blackjack/blackjack.ts
@@ -9,11 +9,17 @@ import {
 import { CommonModule } from '@angular/common';
 import { WebSocketService } from '../../core/services/websocket.service';
 import { AuthService } from '../../core/services/auth.service';
+import {
+  BlackjackStageManager,
+  buildDealerCardId,
+  buildPlayerCardId,
+} from './blackjack-stage-manager';
 
 export interface BlackjackCard {
   rank: string;
   suit: string;
   faceUp: boolean;
+  cardId: string;
 }
 
 export interface BlackjackHand {
@@ -60,9 +66,16 @@ const BJ_SEAT_POSITIONS: Array<{ x: number; y: number }> = [
 export class BlackjackComponent {
   private ws = inject(WebSocketService);
   private auth = inject(AuthService);
+  private stageManager = new BlackjackStageManager({
+    reducedMotion: window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+  });
 
-  readonly stateBlob = this.ws.stateBlob;
+  readonly stateBlob = this.stageManager.displayedStateBlob;
   readonly lastError = this.ws.lastError;
+
+  readonly isAnimating = this.stageManager.isAnimating;
+  readonly stage = this.stageManager.stage;
+  readonly enteringCardIds = this.stageManager.enteringCardIds;
 
   private readonly suitMap: Record<string, string> = {
     h: 'hearts', d: 'diamonds', c: 'clubs', s: 'spades',
@@ -94,10 +107,11 @@ export class BlackjackComponent {
   readonly dealerHand = computed((): BlackjackCard[] => {
     const blob = this.stateBlob();
     const cards = (blob?.['dealerHand'] as string[]) ?? [];
-    return cards.map((c) => ({
+    return cards.map((c, index) => ({
       rank: this.cardRank(c),
       suit: this.cardSuit(c),
       faceUp: c !== 'back',
+      cardId: buildDealerCardId(index, c),
     }));
   });
 
@@ -127,10 +141,11 @@ export class BlackjackComponent {
       const betsArr = p['bets'] as number[] | undefined;
 
       const hands: BlackjackHand[] = (handsArr ?? []).map((handCards, idx) => {
-        const cards: BlackjackCard[] = handCards.map((c) => ({
+        const cards: BlackjackCard[] = handCards.map((c, index) => ({
           rank: this.cardRank(c),
           suit: this.cardSuit(c),
           faceUp: c !== 'back',
+          cardId: buildPlayerCardId(playerId, idx, index, c),
         }));
         const handResult = handResultsArr?.[idx] ?? result;
         return {
@@ -243,6 +258,15 @@ export class BlackjackComponent {
     return labels[this.phase()] ?? this.phase();
   });
 
+  readonly stageMessage = computed(() => {
+    switch (this.stage()) {
+      case 'dealing': return 'Dealing…';
+      case 'dealer-turn': return 'Dealer is drawing…';
+      case 'settling': return 'Settling…';
+      default: return '';
+    }
+  });
+
   // Animation / pacing state
   showAnnouncement = signal(false);
   announcementText = signal('');
@@ -251,42 +275,99 @@ export class BlackjackComponent {
   // Betting state
   betAmount = signal<number>(20);
 
+  // Rendering helpers
+  readonly heroHasBet = computed(() => {
+    return this.heroHands().some((h) => h.bet > 0);
+  });
+
+  readonly showWaitingOverlay = computed(() => {
+    return this.players().length === 0;
+  });
+
+  readonly showStartHint = computed(() => {
+    return this.isBetting() && this.isHeroTurn() && !this.heroHasBet();
+  });
+
+  readonly resultRows = computed(() => {
+    const rows: Array<{
+      name: string;
+      label: string;
+      amount: number;
+      resultClass: string;
+      handName?: string;
+    }> = [];
+
+    for (const player of this.players()) {
+      for (const hand of player.hands) {
+        const status = hand.status;
+        let amount = 0;
+        let label = this.resultLabel(status);
+        let resultClass = this.resultClass(status);
+
+        if (status === 'win' || status === 'blackjack') {
+          amount = hand.bet;
+        } else if (status === 'lose' || status === 'bust') {
+          amount = -hand.bet;
+        }
+
+        rows.push({
+          name: player.name,
+          label,
+          amount,
+          resultClass,
+          handName: player.hands.length > 1 ? `Hand ${player.hands.indexOf(hand) + 1}` : undefined,
+        });
+      }
+    }
+    return rows;
+  });
+
   constructor() {
+    // Feed authoritative state into the stage manager
+    effect(() => {
+      this.stageManager.setTarget(this.ws.stateBlob());
+    });
+
     let lastPhase = '';
     let showdownTimer: number | null = null;
 
     effect(() => {
       const currentPhase = this.phase();
-      if (currentPhase === lastPhase) return;
-      lastPhase = currentPhase;
+      const animating = this.isAnimating();
 
-      // Phase announcements
-      if (currentPhase === 'insurance') {
-        this.announcementText.set('Dealer shows Ace — Insurance?');
-        this.showAnnouncement.set(true);
-        setTimeout(() => this.showAnnouncement.set(false), 2000);
-      } else if (currentPhase === 'dealer') {
-        this.announcementText.set("Dealer's Turn");
-        this.showAnnouncement.set(true);
-        setTimeout(() => this.showAnnouncement.set(false), 1500);
-      } else if (currentPhase === 'showdown') {
-        this.announcementText.set('Showdown');
-        this.showAnnouncement.set(true);
-        setTimeout(() => this.showAnnouncement.set(false), 1500);
-      } else {
-        this.showAnnouncement.set(false);
+      if (currentPhase !== lastPhase) {
+        lastPhase = currentPhase;
+
+        // Phase announcements
+        if (currentPhase === 'insurance') {
+          this.announcementText.set('Dealer shows Ace — Insurance?');
+          this.showAnnouncement.set(true);
+          setTimeout(() => this.showAnnouncement.set(false), 2000);
+        } else if (currentPhase === 'dealer') {
+          this.announcementText.set("Dealer's Turn");
+          this.showAnnouncement.set(true);
+          setTimeout(() => this.showAnnouncement.set(false), 1500);
+        } else if (currentPhase === 'showdown') {
+          this.announcementText.set('Showdown');
+          this.showAnnouncement.set(true);
+          setTimeout(() => this.showAnnouncement.set(false), 1500);
+        } else {
+          this.showAnnouncement.set(false);
+        }
+
+        // Reset bet amount to min when entering betting phase
+        if (currentPhase === 'betting') {
+          this.betAmount.set(this.minBet());
+        }
       }
 
-      // Reset bet amount to min when entering betting phase
-      if (currentPhase === 'betting') {
-        this.betAmount.set(this.minBet());
-      }
-
-      // Delay results overlay so player can see final table state
-      if (currentPhase === 'showdown') {
-        showdownTimer = window.setTimeout(() => {
-          this.showResultsOverlay.set(true);
-        }, 2000);
+      // Results overlay: only trigger once dealer/settle animation is done
+      if (currentPhase === 'showdown' && !animating) {
+        if (!showdownTimer) {
+          showdownTimer = window.setTimeout(() => {
+            this.showResultsOverlay.set(true);
+          }, 2000);
+        }
       } else {
         if (showdownTimer) {
           clearTimeout(showdownTimer);
@@ -353,7 +434,7 @@ export class BlackjackComponent {
   }
 
   canAction(type: string): boolean {
-    return this.validActions().some((a) => a.type === type);
+    return !this.isAnimating() && this.validActions().some((a) => a.type === type);
   }
 
   getHandValueDisplay(hand: BlackjackHand): string {
@@ -373,6 +454,35 @@ export class BlackjackComponent {
 
   cardBackSrc(): string {
     return 'assets/poker_cards/back.png';
+  }
+
+  chipStack(bet: number): string[] {
+    if (bet <= 0) return [];
+    const colors = ['chip--red', 'chip--blue', 'chip--green', 'chip--black', 'chip--gold'];
+    const count = Math.min(8, Math.max(1, Math.ceil(bet / 25)));
+    return Array.from({ length: count }, (_, i) => colors[i % colors.length]);
+  }
+
+  resultClass(status: string): string {
+    switch (status) {
+      case 'win': return 'result--win';
+      case 'blackjack': return 'result--blackjack';
+      case 'lose': return 'result--lose';
+      case 'bust': return 'result--lose';
+      case 'push': return 'result--push';
+      default: return 'result--push';
+    }
+  }
+
+  resultLabel(status: string): string {
+    switch (status) {
+      case 'win': return 'Win';
+      case 'blackjack': return 'Blackjack';
+      case 'lose': return 'Lose';
+      case 'bust': return 'Bust';
+      case 'push': return 'Push';
+      default: return status;
+    }
   }
 
   private cardRank(card: string): string {

--- a/src/frontend/src/app/features/blackjack/blackjack.ts
+++ b/src/frontend/src/app/features/blackjack/blackjack.ts
@@ -70,6 +70,7 @@ export class BlackjackComponent implements OnDestroy {
   private stageManager = new BlackjackStageManager({
     reducedMotion: typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches,
   });
+  private timers = new Set<number>();
 
   readonly stateBlob = this.stageManager.displayedStateBlob;
   readonly lastError = this.ws.lastError;
@@ -332,6 +333,22 @@ export class BlackjackComponent implements OnDestroy {
     let lastPhase = '';
     let showdownTimer: number | null = null;
 
+    const setTimer = (fn: () => void, delay: number): number => {
+      const id = window.setTimeout(() => {
+        this.timers.delete(id);
+        fn();
+      }, delay);
+      this.timers.add(id);
+      return id;
+    };
+
+    const clearTimer = (id: number | null): void => {
+      if (id != null) {
+        clearTimeout(id);
+        this.timers.delete(id);
+      }
+    };
+
     effect(() => {
       const currentPhase = this.phase();
       const animating = this.isAnimating();
@@ -343,15 +360,15 @@ export class BlackjackComponent implements OnDestroy {
         if (currentPhase === 'insurance') {
           this.announcementText.set('Dealer shows Ace — Insurance?');
           this.showAnnouncement.set(true);
-          setTimeout(() => this.showAnnouncement.set(false), 2000);
+          setTimer(() => this.showAnnouncement.set(false), 2000);
         } else if (currentPhase === 'dealer') {
           this.announcementText.set("Dealer's Turn");
           this.showAnnouncement.set(true);
-          setTimeout(() => this.showAnnouncement.set(false), 1500);
+          setTimer(() => this.showAnnouncement.set(false), 1500);
         } else if (currentPhase === 'showdown') {
           this.announcementText.set('Showdown');
           this.showAnnouncement.set(true);
-          setTimeout(() => this.showAnnouncement.set(false), 1500);
+          setTimer(() => this.showAnnouncement.set(false), 1500);
         } else {
           this.showAnnouncement.set(false);
         }
@@ -365,13 +382,13 @@ export class BlackjackComponent implements OnDestroy {
       // Results overlay: only trigger once dealer/settle animation is done
       if (currentPhase === 'showdown' && !animating) {
         if (!showdownTimer) {
-          showdownTimer = window.setTimeout(() => {
+          showdownTimer = setTimer(() => {
             this.showResultsOverlay.set(true);
           }, 2000);
         }
       } else {
         if (showdownTimer) {
-          clearTimeout(showdownTimer);
+          clearTimer(showdownTimer);
           showdownTimer = null;
         }
         this.showResultsOverlay.set(false);
@@ -380,6 +397,10 @@ export class BlackjackComponent implements OnDestroy {
   }
 
   ngOnDestroy(): void {
+    for (const id of this.timers) {
+      clearTimeout(id);
+    }
+    this.timers.clear();
     this.stageManager.destroy();
   }
 

--- a/src/frontend/src/app/features/blackjack/blackjack.ts
+++ b/src/frontend/src/app/features/blackjack/blackjack.ts
@@ -112,7 +112,7 @@ export class BlackjackComponent implements OnDestroy {
       rank: this.cardRank(c),
       suit: this.cardSuit(c),
       faceUp: c !== 'back',
-      cardId: buildDealerCardId(index, c),
+      cardId: buildDealerCardId(index),
     }));
   });
 
@@ -146,7 +146,7 @@ export class BlackjackComponent implements OnDestroy {
           rank: this.cardRank(c),
           suit: this.cardSuit(c),
           faceUp: c !== 'back',
-          cardId: buildPlayerCardId(playerId, idx, index, c),
+          cardId: buildPlayerCardId(playerId, idx, index),
         }));
         const handResult = handResultsArr?.[idx] ?? result;
         return {

--- a/src/frontend/src/app/features/blackjack/blackjack.ts
+++ b/src/frontend/src/app/features/blackjack/blackjack.ts
@@ -4,6 +4,7 @@ import {
   computed,
   effect,
   inject,
+  OnDestroy,
   signal,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
@@ -63,11 +64,11 @@ const BJ_SEAT_POSITIONS: Array<{ x: number; y: number }> = [
   styleUrl: './blackjack.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class BlackjackComponent {
+export class BlackjackComponent implements OnDestroy {
   private ws = inject(WebSocketService);
   private auth = inject(AuthService);
   private stageManager = new BlackjackStageManager({
-    reducedMotion: window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+    reducedMotion: typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches,
   });
 
   readonly stateBlob = this.stageManager.displayedStateBlob;
@@ -376,6 +377,10 @@ export class BlackjackComponent {
         this.showResultsOverlay.set(false);
       }
     });
+  }
+
+  ngOnDestroy(): void {
+    this.stageManager.destroy();
   }
 
   isHeroSeat(seatIdx: number): boolean {

--- a/src/test/blackjack-stage-manager.test.ts
+++ b/src/test/blackjack-stage-manager.test.ts
@@ -65,7 +65,7 @@ describe('BlackjackStageManager', () => {
     // First player card
     jest.advanceTimersByTime(350);
     expect((mgr.displayedStateBlob()?.['players'] as any[])[0].hands[0]).toEqual(['Ah']);
-    expect(mgr.enteringCardIds().has(buildPlayerCardId(1, 0, 0, 'Ah'))).toBe(true);
+    expect(mgr.enteringCardIds().has(buildPlayerCardId(1, 0, 0))).toBe(true);
 
     // Dealer upcard
     jest.advanceTimersByTime(350);
@@ -295,5 +295,39 @@ describe('BlackjackStageManager', () => {
 
     expect(mgr.isAnimating()).toBe(false);
     expect(mgr.displayedStateBlob()?.['dealerHand']).toEqual(['5h', '8c', 'Ks']);
+  });
+
+  it('snaps on split', () => {
+    const mgr = new BlackjackStageManager();
+    mgr.setTarget(
+      makeBlob('player_turn', ['5h', 'back'], [
+        {
+          playerId: 1,
+          username: 'Hero',
+          stack: 1000,
+          hands: [['Ah', '10d']],
+          bets: [20],
+          result: 'playing',
+        },
+      ])
+    );
+    jest.advanceTimersByTime(10_000);
+
+    mgr.setTarget(
+      makeBlob('player_turn', ['5h', 'back'], [
+        {
+          playerId: 1,
+          username: 'Hero',
+          stack: 1000,
+          hands: [['Ah'], ['10d', '3c']],
+          bets: [20, 20],
+          result: 'playing',
+        },
+      ])
+    );
+
+    expect(mgr.isAnimating()).toBe(false);
+    const hands = (mgr.displayedStateBlob()?.['players'] as any[])[0].hands;
+    expect(hands).toEqual([['Ah'], ['10d', '3c']]);
   });
 });

--- a/src/test/blackjack-stage-manager.test.ts
+++ b/src/test/blackjack-stage-manager.test.ts
@@ -132,4 +132,86 @@ describe('BlackjackStageManager', () => {
     expect(mgr.isAnimating()).toBe(false);
     expect(mgr.stage()).toBe('idle');
   });
+
+  it('animates a player hit', () => {
+    const mgr = new BlackjackStageManager();
+    mgr.setTarget(
+      makeBlob('player_turn', ['5h', 'back'], [
+        {
+          playerId: 1,
+          username: 'Hero',
+          stack: 1000,
+          hands: [['Ah', '10d']],
+          bets: [20],
+          result: 'playing',
+        },
+      ])
+    );
+    jest.advanceTimersByTime(10_000);
+
+    mgr.setTarget(
+      makeBlob('player_turn', ['5h', 'back'], [
+        {
+          playerId: 1,
+          username: 'Hero',
+          stack: 1000,
+          hands: [['Ah', '10d', '3c']],
+          bets: [20],
+          result: 'playing',
+        },
+      ])
+    );
+
+    expect(mgr.isAnimating()).toBe(true);
+    expect(mgr.stage()).toBe('player-turn');
+
+    jest.advanceTimersByTime(TIMING.dealStagger);
+    expect((mgr.displayedStateBlob()?.['players'] as any[])[0].hands[0]).toEqual([
+      'Ah',
+      '10d',
+      '3c',
+    ]);
+
+    jest.advanceTimersByTime(TIMING.dealStagger);
+    expect(mgr.isAnimating()).toBe(false);
+  });
+
+  it('animates the settle highlight', () => {
+    const mgr = new BlackjackStageManager();
+    mgr.setTarget(
+      makeBlob('dealer_turn', ['5h', '8c', 'Ks'], [
+        {
+          playerId: 1,
+          username: 'Hero',
+          stack: 1000,
+          hands: [['Ah', '10d']],
+          bets: [20],
+          result: 'won',
+          handResults: ['won'],
+        },
+      ])
+    );
+    jest.advanceTimersByTime(10_000);
+
+    mgr.setTarget(
+      makeBlob('settled', ['5h', '8c', 'Ks'], [
+        {
+          playerId: 1,
+          username: 'Hero',
+          stack: 1020,
+          hands: [['Ah', '10d']],
+          bets: [20],
+          result: 'won',
+          handResults: ['won'],
+        },
+      ])
+    );
+
+    expect(mgr.isAnimating()).toBe(true);
+    expect(mgr.stage()).toBe('settling');
+
+    jest.advanceTimersByTime(TIMING.settlePause);
+    expect((mgr.displayedStateBlob()?.['players'] as any[])[0].result).toBe('won');
+    expect(mgr.isAnimating()).toBe(false);
+  });
 });

--- a/src/test/blackjack-stage-manager.test.ts
+++ b/src/test/blackjack-stage-manager.test.ts
@@ -212,6 +212,43 @@ describe('BlackjackStageManager', () => {
 
     jest.advanceTimersByTime(TIMING.settlePause);
     expect((mgr.displayedStateBlob()?.['players'] as any[])[0].result).toBe('won');
+    expect((mgr.displayedStateBlob()?.['players'] as any[])[0].stack).toBe(1020);
+    expect(mgr.displayedStateBlob()?.['dealerHand']).toEqual(['5h', '8c', 'Ks']);
+    expect(mgr.isAnimating()).toBe(false);
+  });
+
+  it('snaps dealer hand when baseline is incomplete, then settles', () => {
+    const mgr = new BlackjackStageManager();
+    const player = {
+      playerId: 1,
+      username: 'Hero',
+      stack: 1000,
+      hands: [['Ah', '10d']],
+      bets: [20],
+      result: 'playing',
+    };
+
+    mgr.setTarget(makeBlob('dealer_turn', ['5h', '8c', 'Ks'], [player]));
+    expect(mgr.displayedStateBlob()?.['dealerHand']).toEqual(['5h', '8c', 'Ks']);
+    expect(mgr.isAnimating()).toBe(false);
+    expect(mgr.stage()).toBe('idle');
+
+    mgr.setTarget(
+      makeBlob('settled', ['5h', '8c', 'Ks'], [
+        {
+          ...player,
+          stack: 1020,
+          result: 'won',
+          handResults: ['won'],
+        },
+      ])
+    );
+
+    expect(mgr.isAnimating()).toBe(true);
+    expect(mgr.stage()).toBe('settling');
+
+    jest.advanceTimersByTime(TIMING.settlePause);
+    expect((mgr.displayedStateBlob()?.['players'] as any[])[0].result).toBe('won');
     expect(mgr.isAnimating()).toBe(false);
   });
 });

--- a/src/test/blackjack-stage-manager.test.ts
+++ b/src/test/blackjack-stage-manager.test.ts
@@ -251,4 +251,49 @@ describe('BlackjackStageManager', () => {
     expect((mgr.displayedStateBlob()?.['players'] as any[])[0].result).toBe('won');
     expect(mgr.isAnimating()).toBe(false);
   });
+
+  it('snaps instantly when reduced motion is preferred', () => {
+    const mgr = new BlackjackStageManager({ reducedMotion: true });
+    mgr.setTarget(
+      makeBlob('player_turn', ['5h', 'back'], [
+        {
+          playerId: 1,
+          username: 'Hero',
+          stack: 1000,
+          hands: [['Ah', '10d']],
+          bets: [20],
+          result: 'playing',
+        },
+      ])
+    );
+
+    expect(mgr.isAnimating()).toBe(false);
+    expect((mgr.displayedStateBlob()?.['players'] as any[])[0].hands[0]).toEqual([
+      'Ah',
+      '10d',
+    ]);
+  });
+
+  it('jumps ahead on reconnect or phase skip', () => {
+    const mgr = new BlackjackStageManager();
+    mgr.setTarget(makeBlob('betting', [], []));
+    jest.advanceTimersByTime(0);
+
+    // Dealer phase would normally animate, but we leap from betting → dealer
+    mgr.setTarget(
+      makeBlob('dealer_turn', ['5h', '8c', 'Ks'], [
+        {
+          playerId: 1,
+          username: 'Hero',
+          stack: 1000,
+          hands: [['Ah', '10d']],
+          bets: [20],
+          result: 'playing',
+        },
+      ])
+    );
+
+    expect(mgr.isAnimating()).toBe(false);
+    expect(mgr.displayedStateBlob()?.['dealerHand']).toEqual(['5h', '8c', 'Ks']);
+  });
 });

--- a/src/test/blackjack-stage-manager.test.ts
+++ b/src/test/blackjack-stage-manager.test.ts
@@ -1,0 +1,41 @@
+jest.mock('@angular/core', () => ({
+  signal: <T>(initialValue: T) => {
+    let value = initialValue;
+    const fn = () => value;
+    fn.set = (v: T) => { value = v; };
+    return fn;
+  },
+}));
+
+import { BlackjackStageManager } from '../frontend/src/app/features/blackjack/blackjack-stage-manager';
+
+function makeBlob(
+  phase: string,
+  dealerHand: string[],
+  players: Record<string, unknown>[]
+): Record<string, unknown> {
+  return {
+    status: 'active',
+    phase,
+    dealerHand,
+    players,
+    activePlayer: -1,
+    activeHandIndex: 0,
+    currentBet: 20,
+    validActions: [],
+  };
+}
+
+describe('BlackjackStageManager', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  it('snaps to a betting state instantly', () => {
+    const mgr = new BlackjackStageManager();
+    mgr.setTarget(makeBlob('betting', [], []));
+
+    expect(mgr.displayedStateBlob()?.['phase']).toBe('betting');
+    expect(mgr.isAnimating()).toBe(false);
+    expect(mgr.stage()).toBe('idle');
+  });
+});

--- a/src/test/blackjack-stage-manager.test.ts
+++ b/src/test/blackjack-stage-manager.test.ts
@@ -7,7 +7,7 @@ jest.mock('@angular/core', () => ({
   },
 }));
 
-import { BlackjackStageManager } from '../frontend/src/app/features/blackjack/blackjack-stage-manager';
+import { BlackjackStageManager, buildPlayerCardId, buildDealerCardId, TIMING } from '../frontend/src/app/features/blackjack/blackjack-stage-manager';
 
 function makeBlob(
   phase: string,
@@ -35,6 +35,52 @@ describe('BlackjackStageManager', () => {
     mgr.setTarget(makeBlob('betting', [], []));
 
     expect(mgr.displayedStateBlob()?.['phase']).toBe('betting');
+    expect(mgr.isAnimating()).toBe(false);
+    expect(mgr.stage()).toBe('idle');
+  });
+
+  it('stages an initial deal one card at a time', () => {
+    const mgr = new BlackjackStageManager();
+    mgr.setTarget(makeBlob('betting', [], []));
+    jest.advanceTimersByTime(0);
+
+    const target = makeBlob('player_turn', ['5h', 'back'], [
+      {
+        playerId: 1,
+        username: 'Hero',
+        stack: 1000,
+        hands: [['Ah', '10d']],
+        bets: [20],
+        result: 'playing',
+      },
+    ]);
+
+    mgr.setTarget(target);
+
+    // Reset event applies immediately (delay 0)
+    expect(mgr.isAnimating()).toBe(true);
+    expect(mgr.stage()).toBe('dealing');
+    expect((mgr.displayedStateBlob()?.['players'] as any[])[0].hands[0]).toEqual([]);
+
+    // First player card
+    jest.advanceTimersByTime(350);
+    expect((mgr.displayedStateBlob()?.['players'] as any[])[0].hands[0]).toEqual(['Ah']);
+    expect(mgr.enteringCardIds().has(buildPlayerCardId(1, 0, 0, 'Ah'))).toBe(true);
+
+    // Dealer upcard
+    jest.advanceTimersByTime(350);
+    expect(mgr.displayedStateBlob()?.['dealerHand']).toEqual(['5h']);
+
+    // Second player card
+    jest.advanceTimersByTime(350);
+    expect((mgr.displayedStateBlob()?.['players'] as any[])[0].hands[0]).toEqual(['Ah', '10d']);
+
+    // Dealer hole
+    jest.advanceTimersByTime(350);
+    expect(mgr.displayedStateBlob()?.['dealerHand']).toEqual(['5h', 'back']);
+
+    // Queue finishes
+    jest.advanceTimersByTime(350);
     expect(mgr.isAnimating()).toBe(false);
     expect(mgr.stage()).toBe('idle');
   });

--- a/src/test/blackjack-stage-manager.test.ts
+++ b/src/test/blackjack-stage-manager.test.ts
@@ -84,4 +84,52 @@ describe('BlackjackStageManager', () => {
     expect(mgr.isAnimating()).toBe(false);
     expect(mgr.stage()).toBe('idle');
   });
+
+  it('reveals the hole card and draws dealer cards one by one', () => {
+    const mgr = new BlackjackStageManager();
+
+    // Start from a fully dealt playing state
+    mgr.setTarget(
+      makeBlob('player_turn', ['5h', 'back'], [
+        {
+          playerId: 1,
+          username: 'Hero',
+          stack: 1000,
+          hands: [['Ah', '10d']],
+          bets: [20],
+          result: 'playing',
+        },
+      ])
+    );
+    jest.advanceTimersByTime(10_000); // finish initial deal
+
+    mgr.setTarget(
+      makeBlob('dealer_turn', ['5h', '8c', 'Ks'], [
+        {
+          playerId: 1,
+          username: 'Hero',
+          stack: 1000,
+          hands: [['Ah', '10d']],
+          bets: [20],
+          result: 'playing',
+        },
+      ])
+    );
+
+    expect(mgr.isAnimating()).toBe(true);
+    expect(mgr.stage()).toBe('dealer-turn');
+
+    // Hole card revealed
+    jest.advanceTimersByTime(TIMING.holeFlip);
+    expect(mgr.displayedStateBlob()?.['dealerHand']).toEqual(['5h', '8c']);
+
+    // First dealer draw
+    jest.advanceTimersByTime(TIMING.dealerDrawPause);
+    expect(mgr.displayedStateBlob()?.['dealerHand']).toEqual(['5h', '8c', 'Ks']);
+
+    // Queue finishes
+    jest.advanceTimersByTime(TIMING.dealerDrawPause);
+    expect(mgr.isAnimating()).toBe(false);
+    expect(mgr.stage()).toBe('idle');
+  });
 });


### PR DESCRIPTION
## Summary

This PR adds a frontend-only staged animation layer to Blackjack so the game flow feels more satisfying and tense:

- **Staggered initial deal:** cards are dealt one at a time to each player and the dealer.
- **Dealer tension:** the hole card flips, then the dealer draws each hit card with a visible pause instead of spawning the whole hand at once.
- **Animated player hits:** new cards fly in when the player hits or doubles.
- **Result reveal:** winning/losing hands get colored highlights and chips animate on wins before the results overlay appears.
- **Reduced motion support:** users with `prefers-reduced-motion: reduce` see the final state instantly.
- **Resilient to reconnects:** big state jumps (e.g., refresh mid-round or split hands) snap to the authoritative state rather than animating from an inconsistent baseline.

## Implementation

- New `BlackjackStageManager` compares the authoritative WebSocket state with the currently displayed state and replays card differences through a timed event queue.
- Component renders from the staged `displayedStateBlob`, disables controls while `isAnimating()` is true, and delays the results overlay until animations finish.
- CSS updated so only newly entering cards animate, card backgrounds are transparent, hero cards stay above the control bar, and result highlights/chip payout animations are added.

## Tests

- `src/test/blackjack-stage-manager.test.ts` (9 tests) covers:
  - initial deal staging
  - dealer hole reveal and draws
  - player hit animation
  - settle highlight
  - reduced-motion snap
  - reconnect/phase-skip jump
  - split-hand snap

## Verification

- `npm run frontend:build` ✅
- `npm test` ✅ (773 tests passing)